### PR TITLE
add empty slices to sunburst

### DIFF
--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -319,17 +319,17 @@ function initSunburst(data) {
 
     textEnter.append("tspan")
         .attr("x", 0)
-        .text(function (d) { return d.depth ? d.name.split(" ")[0] : ""; });
+        .text(function (d) { return d.depth && d.name !== "empty" ? d.name.split(" ")[0] : ""; });
 
     textEnter.append("tspan")
         .attr("x", 0)
         .attr("dy", "1em")
-        .text(function (d) { return d.depth ? d.name.split(" ")[1] || "" : ""; });
+        .text(function (d) { return d.depth && d.name !== "empty" ? d.name.split(" ")[1] || "" : ""; });
 
     textEnter.append("tspan")
         .attr("x", 0)
         .attr("dy", "1em")
-        .text(function (d) { return d.depth ? d.name.split(" ")[2] || "" : ""; });
+        .text(function (d) { return d.depth && d.name !== "empty" ? d.name.split(" ")[2] || "" : ""; });
 
     textEnter.style("font-size", function (d) {
         return Math.min(((r / levels) / this.getComputedTextLength() * 10) + 1, 12) + "px";
@@ -339,6 +339,9 @@ function initSunburst(data) {
     setTimeout(function () {click(data); }, 1000);
 
     function click(d) {
+        if (d.name === "empty") {
+            return;
+        }
         // GA event tracking
         _gaq.push(['_trackEvent', 'Multi Peptide', 'Zoom', 'Sunburst']);
 
@@ -448,7 +451,7 @@ function initSunburst(data) {
 
     // tooltip functions
     function tooltipIn(d, i) {
-        if (d.depth < currentMaxLevel) {
+        if (d.depth < currentMaxLevel && d.name !== "empty") {
             tooltip.style("visibility", "visible")
                 .html("<b>" + d.name + "</b> (" + d.attr.title + ")<br/>" +
                     (!d.data.self_count ? "0" : d.data.self_count) +
@@ -478,7 +481,7 @@ function initSunburst(data) {
             }
         }
         if (kids.length > 0 && count !== 0 && count !== undefined) {
-            kids.push({id: -1, name: "empty", data: {count: count, self_count: count}, attr: {title: "empty"}});
+            kids.push({id: -1, name: "empty", data: {count: count, self_count: count}});
         }
         return kids;
     }

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -127,7 +127,7 @@ function initTreeMap(jsonData) {
             // add positioning offsets
             offsetX: 20,
             offsetY: 20,
-            // implement the onShow method to add content 
+            // implement the onShow method to add content
             // to the tooltip when a node is hovered
             onShow: function (tip, node, isLeaf, domElement) {
                 tip.innerHTML = "<div class='tip-title'><b>" + node.name + "</b> (" + node.data.rank + ")</div><div class='tip-text'>" +

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -247,6 +247,9 @@ function initJsTree(data, equate_il) {
 }
 
 function initSunburst(data) {
+    // add empty slices
+    data.kids = addEmptyChildren(data.kids, data.data.self_count);
+
     var w = 730,   // width
         h = w,     // height
         r = w / 2, // radius
@@ -282,7 +285,7 @@ function initSunburst(data) {
     var partition = d3.layout.partition()               // creates a new partition layout
         .sort(null)                                     // don't sort,  use tree traversal order
         .value(function (d) { return d.data.self_count; })    // set the size of the pieces
-        .children(function (d) {return d.kids; });
+        .children(function (d) { return d.kids; });
 
     // calculate arcs out of partition coordinates
     var arc = d3.svg.arc()
@@ -461,6 +464,19 @@ function initSunburst(data) {
     function tooltipOut(d, i) {
         tooltip.style("visibility", "hidden");
         // vis.selectAll("#path-" + i).transition().duration(200).style("fill-opacity","1");
+    }
+
+    function addEmptyChildren(kids, count) {
+        var i;
+        for (i = 0; i < kids.length; i++) {
+            if (typeof kids[i].kids !== "undefined") {
+                kids[i].kids = addEmptyChildren(kids[i].kids, kids[i].data.self_count);
+            }
+        }
+        if (count !== 0) {
+            kids.push({id: -1, name: "empty", data: {count: count, self_count: count}});
+        }
+        return kids;
     }
 }
 

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -400,12 +400,16 @@ function initSunburst(data) {
 
     // Calculates the color of an arc based on the color of his children
     function colour(d) {
+        if ( d.name === "empty") {
+            return "white";
+        }
         if (d.children) {
             var colours = d.children.map(colour),
                 a = d3.hsl(colours[0]),
-                b = d3.hsl(colours[1]);
+                b = d3.hsl(colours[1]),
+                singleChild = d.children.length === 1 || d.children[1].name === "empty";
             // if we only have one child, return a slightly darker variant of the child color
-            if (!colours[1]) {
+            if (singleChild) {
                 return d3.hsl(a.h, a.s, a.l * 0.98);
             }
             // if we have 2 kids or more, take the average of the first two kids
@@ -473,8 +477,8 @@ function initSunburst(data) {
                 kids[i].kids = addEmptyChildren(kids[i].kids, kids[i].data.self_count);
             }
         }
-        if (count !== 0) {
-            kids.push({id: -1, name: "empty", data: {count: count, self_count: count}});
+        if (kids.length > 0 && count !== 0 && count !== undefined) {
+            kids.push({id: -1, name: "empty", data: {count: count, self_count: count}, attr: {title: "empty"}});
         }
         return kids;
     }


### PR DESCRIPTION
#21 
The size of an arc is calculated by taking the sum of the sizes of its "children". If a node doesn't have any children, its size is proportional to the number of peptides unique to that node.
Let's look at a toy example:

```
Parent (15)
|--Child 1 (7)
| |--Subchild 1 (1)
| |--Subchild 2 (3)
|--Child 2 (3)
```
- Both subchildren have no children, so their sizes are proportional to the number of peptides they have (1 and 3). 
- Child 1 has two children, so its size is the sum of the sizes of the children (3+1 = 4)
- Child 2 has no children, so its size is 3
- Parent has two children, so its size is the sum of the sizes of child 1 and 2 (4+3 = 7)

As you can see, the size of the parent (7) doesn't match with the number of peptides of that node (15). This is probably what you also experienced. The problem lies in the fact that Child 1 has 4 peptides that are unique to that node that aren't incorporated into its size. The same thing happens with the 5 peptides specific to the parent node.

To fix the sizes, the sunburst should be drawn like this:

```
Parent (15)
|--Child 1 (7)
| |--Subchild 1 (1)
| |--Subchild 2 (3)
| |--Invisible subchild (7-1-3=3)
|--Child 2 (3)
|--Invisible child (15-7-3=5)
```


_[Original pull request](https://github.ugent.be/unipept/unipept/pull/172) by @bmesuere on Sun Oct 27 2013 at 15:28._
_Merged by @bmesuere on Sun Oct 27 2013 at 16:51._