### PR TITLE
add exception notification gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,9 @@ end
 # Use unicorn as the web server
 # gem 'unicorn'
 
+# Exception emails
+gem 'exception_notification'
+
 # Deploy with Capistrano
 gem 'capistrano', '~> 3.0'
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,9 @@ GEM
     commonjs (0.2.7)
     diff-lcs (1.2.5)
     erubis (2.7.0)
+    exception_notification (4.0.1)
+      actionmailer (>= 3.0.4)
+      activesupport (>= 3.0.4)
     execjs (2.0.2)
     hike (1.2.3)
     httparty (0.13.1)
@@ -187,6 +190,7 @@ DEPENDENCIES
   capistrano-bundler (~> 1.1)
   capistrano-rails (~> 1.1)
   capistrano-rvm
+  exception_notification
   httparty
   jquery-rails
   jquery-ui-rails (= 4.0.2)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,4 +34,10 @@ UnipeptWeb::Application.configure do
   # with SQLite, MySQL, and PostgreSQL)
   #config.active_record.auto_explain_threshold_in_seconds = 30
 end
+UnipeptWeb::Application.config.middleware.use ExceptionNotification::Rack,
+  :email => {
+    :email_prefix => "[Unipept] ",
+    :sender_address => %{"notifier" <unipept@ugent.be>},
+    :exception_recipients => %w{bart.mesuere@ugent.be, toon.willems@ugent.be}
+  }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,6 +38,8 @@ UnipeptWeb::Application.configure do
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.delivery_method = :sendmail
+
   # Enable threaded mode
   # config.threadsafe!
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,3 +57,9 @@ UnipeptWeb::Application.configure do
   # Generate digests for assets URLs
   config.assets.digest = true
 end
+UnipeptWeb::Application.config.middleware.use ExceptionNotification::Rack,
+  :email => {
+    :email_prefix => "[Unipept] ",
+    :sender_address => %{"notifier" <unipept@ugent.be>},
+    :exception_recipients => %w{bart.mesuere@ugent.be, toon.willems@ugent.be}
+  }


### PR DESCRIPTION
Closes #283 

Actionmailer configuration needs to be done. 

I suggest using `sendmail` which is easy to setup.


_[Original pull request](https://github.ugent.be/unipept/unipept/pull/312) by ghost on Mon May 12 2014 at 09:20._
_Merged by @bmesuere on Tue May 13 2014 at 13:46._