### PR TITLE
add treeview to multi search

### DIFF
--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -31,6 +31,13 @@ function init_multi(data, data2, equate_il) {
         error(err.message, "Loading the Treemap visualization failed. Please use Google Chrome, Firefox or Internet Explorer 9 or higher.");
     }
 
+    // treeview
+    try {
+        initTreeView(data);
+    } catch (err) {
+        error(err.message, "Loading the Treeview visualization failed. Please use Google Chrome, Firefox or Internet Explorer 9 or higher.");
+    }
+
     // tree
     try {
         initTree(data, equate_il);
@@ -164,6 +171,122 @@ function initTreeMap(jsonData) {
     tm.refresh();
 
     window.tm = tm;
+}
+
+function initTreeView(jsonData) {
+    var st = new $jit.ST({
+        injectInto: 'jitTreeView',
+        // id of viz container element
+        duration: 800,
+        // set duration for the animation
+        transition: $jit.Trans.Quart.easeInOut,
+        // set animation transition type
+        levelDistance: 50,
+        // set distance between node and its children
+        levelsToShow: 4,
+        // offsetY: 170,
+        // orientation: 'top',
+        offsetX: 350,
+
+        // enable panning
+        Navigation: {
+            enable: true,
+            panning: true
+        },
+
+        // set node and edge styles
+        Node: {
+            autoHeight: true,
+            // autoWidth: true,
+            width: 100,
+            // also change the CSS .node property if you change this!
+            type: 'rectangle',
+            color: '#DCDFE4',
+            overridable: true,
+            align: 'center'
+        },
+
+        Edge: {
+            type: 'bezier',
+            color: '#DCDFE4',
+            overridable: true
+        },
+
+        // This method is called on DOM label creation.
+        // Use this method to add event handlers and styles to
+        // your node.
+        onCreateLabel: function (label, node) {
+            label.id = node.id;
+            label.innerHTML = node.name;
+            label.onclick = function () {
+                st.onClick(node.id);
+                // st.setRoot(node.id, 'animate');
+            };
+            // set label styles => TODO: fix the labels with these settings instead of CSS
+            var style = label.style;
+            style.width = '60px';
+            style.height = '17px';
+            style.cursor = 'pointer';
+            style.color = '#333';
+            style.fontSize = '0.8em';
+            style.textAlign = 'center';
+            style.paddingTop = '3px';
+        },
+
+        // This method is called right before plotting
+        // a node. It's useful for changing an individual node
+        // style properties before plotting it.
+        // The data properties prefixed with a dollar
+        // sign will override the global node style properties.
+        onBeforePlotNode: function (node) {
+            // add some color to the nodes in the path between the
+            // root node and the selected node.
+            if (node.selected) {
+                node.data.$color = "#bbb";
+            }
+            else {
+                delete node.data.$color;
+                // if the node belongs to the last plotted level
+                /*if(!node.anySubnode("exist")) {
+                    // count children number
+                    var count = 0;
+                    node.eachSubnode(function(n) { count++; });
+                    // assign a node color based on
+                    // how many children it has
+                    node.data.$color = ['#aaa', '#baa', '#caa', '#daa', '#eaa', '#faa'][count];
+                }*/
+            }
+        }
+
+        // This method is called right before plotting
+        // an edge. It's useful for changing an individual edge
+        // style properties before plotting it.
+        // Edge data proprties prefixed with a dollar sign will
+        // override the Edge global style properties.
+        /*onBeforePlotLine: function (adj) {
+            if (adj.nodeFrom.selected && adj.nodeTo.selected) {
+                adj.data.$color = "#eed";
+                adj.data.$lineWidth = 3;
+            } else {
+                delete adj.data.$color;
+                delete adj.data.$lineWidth;
+            }
+        }*/
+    });
+    // load json data
+    st.loadJSON(jsonData);
+    console.log(jsonData);
+
+    // compute node positions and layout
+    st.compute();
+
+    // optional: make a translation of the tree
+    st.geom.translate(new $jit.Complex(-200, 0), "current");
+
+    st.onClick(jsonData.id);
+
+    // disable the text selection of tree nodes
+    $("#jitTreeView").disableSelection();
 }
 
 function initTree(data, equate_il) {

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -204,7 +204,8 @@ function initTreeView(jsonData) {
         width = 916 - margin.right - margin.left,
         height = 600 - margin.top - margin.bottom;
 
-    var rightClicked;
+    var rightClicked,
+        zoomEnd = 0;
 
     var i = 0,
         duration = 750,
@@ -219,7 +220,9 @@ function initTreeView(jsonData) {
     var widthScale = d3.scale.linear().range([2,105]);
 
     // define the zoomListener which calls the zoom function on the "zoom" event constrained within the scaleExtents
-    var zoomListener = d3.behavior.zoom().scaleExtent([0.1, 3]).on("zoom", zoom);
+    var zoomListener = d3.behavior.zoom()
+        .scaleExtent([0.1, 3])
+        .on("zoom", zoom);
 
     var svg = d3.select("#d3TreeView").append("svg")
         .attr("version", "1.1")
@@ -466,13 +469,16 @@ function initTreeView(jsonData) {
 
     // Toggle children on click.
     function click(d) {
-      if (d.children) {
-        collapse(d);
-      } else {
-        expand(d);
-      }
-      update(d);
-      centerNode(d);
+        // check if click is triggered by panning on a node
+        if (Date.now() - zoomEnd < 200) return;
+
+        if (d.children) {
+            collapse(d);
+        } else {
+            expand(d);
+        }
+        update(d);
+        centerNode(d);
     }
 
     // Sets the width of the right clicked node to 100%
@@ -509,6 +515,7 @@ function initTreeView(jsonData) {
 
     // Zoom function
     function zoom() {
+        zoomEnd = Date.now();
         svg.attr("transform", "translate(" + d3.event.translate + ")scale(" + d3.event.scale + ")");
     }
 

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -181,6 +181,7 @@ function initTreeMap(jsonData) {
  * Zoomable treeview based on
  * - http://bl.ocks.org/mbostock/4339083
  * - https://gist.github.com/robschmuecker/7880033
+ * - http://www.brightpointinc.com/interactive/budget/index.html?source=d3js
  */
 function initTreeView(jsonData) {
     var margin = {top: 5, right: 5, bottom: 5, left: 60},
@@ -300,7 +301,7 @@ function initTreeView(jsonData) {
               return widthScale(d.data.count) / 2;
           })
           .style("fill-opacity", function(d) { return d._children ? 1 : 0; })
-          .style("fill", function(d) { return d._children ? d.color : "#fff"; });
+          .style("fill", function(d) { return d._children ? d.color || "#aaa" : "#fff"; });
 
       nodeUpdate.select("text")
           .style("fill-opacity", 1);

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -18,7 +18,7 @@ function init_multi(data, data2, equate_il) {
 
     // sunburst
     try {
-        initSunburst(data2);
+        initSunburst(JSON.parse(JSON.stringify(data2)));
     } catch (err) {
         error(err.message, "Loading the Sunburst visualization failed. Please use Google Chrome, Firefox or Internet Explorer 9 or higher.");
     }
@@ -33,7 +33,7 @@ function init_multi(data, data2, equate_il) {
 
     // treeview
     try {
-        initTreeView(JSON.parse(JSON.stringify(data)));
+        initTreeView(data2);
     } catch (err) {
         error(err.message, "Loading the Treeview visualization failed. Please use Google Chrome, Firefox or Internet Explorer 9 or higher.");
     }
@@ -252,6 +252,16 @@ function initTreeView(jsonData) {
         root = data;
         root.x0 = height / 2;
         root.y0 = 0;
+
+        // convert kids to children
+        function kids(d) {
+            if (d.kids) {
+                d.kids.forEach(kids);
+                d.children = d.kids;
+                d.kids = null;
+            }
+        }
+        kids(root);
 
         // set everything visible
         function setVisible(d) {

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -52,9 +52,12 @@ function init_multi(data, data2, equate_il) {
             if ($(".tab-content .active").attr('id') === "sunburstWrapper") {
                 logToGoogle("Multi Peptide", "Full Screen", "Sunburst");
                 window.fullScreenApi.requestFullScreen($("#sunburst").get(0));
-            } else {
+            } else if ($(".tab-content .active").attr('id') === "treeMapWrapper") {
                 logToGoogle("Multi Peptide", "Full Screen", "Treemap");
                 window.fullScreenApi.requestFullScreen($("#treeMap").get(0));
+            } else {
+                logToGoogle("Multi Peptide", "Full Screen", "Treeview");
+                window.fullScreenApi.requestFullScreen($("#d3TreeView").get(0));
             }
         });
         $(document).bind(fullScreenApi.fullScreenEventName, resizeFullScreen);
@@ -73,7 +76,7 @@ function init_multi(data, data2, equate_il) {
                 $("#sunburst svg").attr("height", size);
                 $("#sunburst-tooltip").appendTo(destination);
             }, 1000);
-        } else {
+        } else if ($(".tab-content .active").attr('id') === "treeMapWrapper") {
             var destination = "body";
             if (window.fullScreenApi.isFullScreen()) {
                 destination = "#treeMap";
@@ -81,6 +84,20 @@ function init_multi(data, data2, equate_il) {
             $("#_tooltip").appendTo(destination);
             window.tm.canvas.resize($("#treeMap").width(), $("#treeMap").height());
 
+        } else {
+            setTimeout(function () {
+                var width = 916,
+                    height = 600,
+                    destination = "body";
+                if (window.fullScreenApi.isFullScreen()) {
+                    width = $(window).width();
+                    height = $(window).height();
+                    destination = "#d3TreeView";
+                }
+                $("#d3TreeView svg").attr("width", width);
+                $("#d3TreeView svg").attr("height", height);
+                //$("#d3TreeView-tooltip").appendTo(destination);
+            }, 1000);
         }
     }
 
@@ -178,7 +195,7 @@ function initTreeMap(jsonData) {
 }
 
 /**
- * Zoomable treeview based on
+ * Zoomable treeview, inspiration from
  * - http://bl.ocks.org/mbostock/4339083
  * - https://gist.github.com/robschmuecker/7880033
  * - http://www.brightpointinc.com/interactive/budget/index.html?source=d3js
@@ -206,6 +223,9 @@ function initTreeView(jsonData) {
     var zoomListener = d3.behavior.zoom().scaleExtent([0.1, 3]).on("zoom", zoom);
 
     var svg = d3.select("#d3TreeView").append("svg")
+        .attr("version", "1.1")
+        .attr("xmlns", "http://www.w3.org/2000/svg")
+        .attr("viewBox", "0 0 " + (width + margin.right + margin.left) + " " + (height + margin.top + margin.bottom))
         .attr("width", width + margin.right + margin.left)
         .attr("height", height + margin.top + margin.bottom)
         .call(zoomListener)

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -205,7 +205,8 @@ function initTreeView(jsonData) {
         height = 600 - margin.top - margin.bottom;
 
     var rightClicked,
-        zoomEnd = 0;
+        zoomEnd = 0,
+        tooltipTimer;
 
     var i = 0,
         duration = 750,
@@ -545,8 +546,7 @@ function initTreeView(jsonData) {
 
     // tooltip functions
     function tooltipIn(d, i) {
-        tooltip.style("visibility", "visible")
-            .html("<b>" + d.name + "</b> (" + d.data.rank + ")<br/>" +
+        tooltip.html("<b>" + d.name + "</b> (" + d.data.rank + ")<br/>" +
                 (!d.data.self_count ? "0" : d.data.self_count) +
                 (d.data.self_count && d.data.self_count === 1 ? " sequence" : " sequences") + " specific to this level<br/>" +
                 (!d.data.count ? "0" : d.data.count) +
@@ -557,8 +557,13 @@ function initTreeView(jsonData) {
                 tooltip.style("top", (d3.event.pageY - 5) + "px").style("left", (d3.event.pageX + 15) + "px");
             }
 
+        tooltipTimer = setTimeout(function () {
+            tooltip.style("visibility", "visible");
+        }, 1000);
+
     }
     function tooltipOut(d, i) {
+        clearTimeout(tooltipTimer)
         tooltip.style("visibility", "hidden");
     }
 }

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -33,15 +33,7 @@ function init_multi(data, data2, equate_il) {
 
     // treeview
     try {
-        initTreeView(data);
-        $("#jitTreeViewWrapper").removeClass("active");
-    } catch (err) {
-        error(err.message, "Loading the Treeview visualization failed. Please use Google Chrome, Firefox or Internet Explorer 9 or higher.");
-    }
-
-    // treeview2
-    try {
-        initTreeView2(JSON.parse(JSON.stringify(data)));
+        initTreeView(JSON.parse(JSON.stringify(data)));
     } catch (err) {
         error(err.message, "Loading the Treeview visualization failed. Please use Google Chrome, Firefox or Internet Explorer 9 or higher.");
     }
@@ -185,141 +177,12 @@ function initTreeMap(jsonData) {
     }
 }
 
-function initTreeView(jsonData) {
-    var st = new $jit.ST({
-        injectInto: 'jitTreeView',
-        // id of viz container element
-        duration: 800,
-        // set duration for the animation
-        transition: $jit.Trans.Quart.easeInOut,
-        // set animation transition type
-        levelDistance: 50,
-        // set distance between node and its children
-        levelsToShow: 4,
-        // offsetY: 170,
-        // orientation: 'top',
-        offsetX: 350,
-
-        // enable panning
-        Navigation: {
-            enable: true,
-            panning: true
-        },
-
-        // set node and edge styles
-        Node: {
-            autoHeight: true,
-            // autoWidth: true,
-            width: 100,
-            // also change the CSS .node property if you change this!
-            type: 'rectangle',
-            color: '#DCDFE4',
-            overridable: true,
-            align: 'center'
-        },
-
-        Label: {
-            type: 'Native'
-        },
-
-        Edge: {
-            type: 'bezier',
-            color: '#DCDFE4',
-            overridable: true
-        },
-
-        Events: {
-            enable: true,
-            onClick: function (node) {
-                console.log(node);
-                /*if (node) {
-                    logToGoogle("Multi Peptide", "Zoom", "Treemap", "In");
-                    tm.enter(node);
-                    treeSearch(node.name, 500);
-                }*/
-            }
-        },
-
-        // This method is called on DOM label creation.
-        // Use this method to add event handlers and styles to
-        // your node.
-        /*onCreateLabel: function (label, node) {
-            console.log(node);
-            label.id = node.id;
-            label.innerHTML = node.name;
-            label.onclick = function () {
-                st.onClick(node.id);
-                // st.setRoot(node.id, 'animate');
-            };
-            // set label styles => TODO: fix the labels with these settings instead of CSS
-            var style = label.style;
-            style.width = '60px';
-            style.height = '17px';
-            style.cursor = 'pointer';
-            style.color = '#333';
-            style.fontSize = '0.8em';
-            style.textAlign = 'center';
-            style.paddingTop = '3px';
-        },*/
-
-        // This method is called right before plotting
-        // a node. It's useful for changing an individual node
-        // style properties before plotting it.
-        // The data properties prefixed with a dollar
-        // sign will override the global node style properties.
-        onBeforePlotNode: function (node) {
-            // add some color to the nodes in the path between the
-            // root node and the selected node.
-            if (node.selected) {
-                node.data.$color = "#bbb";
-            }
-            else {
-                delete node.data.$color;
-                // if the node belongs to the last plotted level
-                /*if(!node.anySubnode("exist")) {
-                    // count children number
-                    var count = 0;
-                    node.eachSubnode(function(n) { count++; });
-                    // assign a node color based on
-                    // how many children it has
-                    node.data.$color = ['#aaa', '#baa', '#caa', '#daa', '#eaa', '#faa'][count];
-                }*/
-            }
-        }
-
-        // This method is called right before plotting
-        // an edge. It's useful for changing an individual edge
-        // style properties before plotting it.
-        // Edge data proprties prefixed with a dollar sign will
-        // override the Edge global style properties.
-        /*onBeforePlotLine: function (adj) {
-            if (adj.nodeFrom.selected && adj.nodeTo.selected) {
-                adj.data.$color = "#eed";
-                adj.data.$lineWidth = 3;
-            } else {
-                delete adj.data.$color;
-                delete adj.data.$lineWidth;
-            }
-        }*/
-    });
-    // load json data
-    st.loadJSON(jsonData);
-
-    // compute node positions and layout
-    st.compute();
-
-    // optional: make a translation of the tree
-    st.geom.translate(new $jit.Complex(-200, 0), "current");
-
-    st.onClick(st.root);
-}
-
 /**
  * Zoomable treeview based on
  * - http://bl.ocks.org/mbostock/4339083
  * - https://gist.github.com/robschmuecker/7880033
  */
-function initTreeView2(jsonData) {
+function initTreeView(jsonData) {
     var margin = {top: 5, right: 5, bottom: 5, left: 60},
         width = 916 - margin.right - margin.left,
         height = 600 - margin.top - margin.bottom;

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -34,6 +34,7 @@ function init_multi(data, data2, equate_il) {
     // treeview
     try {
         initTreeView(data);
+        $("#jitTreeViewWrapper").removeClass("active");
     } catch (err) {
         error(err.message, "Loading the Treeview visualization failed. Please use Google Chrome, Firefox or Internet Explorer 9 or higher.");
     }
@@ -171,9 +172,32 @@ function initTreeMap(jsonData) {
     tm.refresh();
 
     window.tm = tm;
+
+    function createLabel(domElement, node) {
+
+    }
 }
 
 function initTreeView(jsonData) {
+    var labelType,
+        useGradients,
+        nativeTextSupport,
+        animate;
+
+    (function () {
+        var ua = navigator.userAgent,
+            iStuff = ua.match(/iPhone/i) || ua.match(/iPad/i),
+            typeOfCanvas = typeof HTMLCanvasElement,
+            nativeCanvasSupport = (typeOfCanvas === 'object' || typeOfCanvas === 'function'),
+            textSupport = nativeCanvasSupport && (typeof document.createElement('canvas').getContext('2d').fillText === 'function');
+        // I'm setting this based on the fact that ExCanvas provides text support for IE
+        // and that as of today iPhone/iPad current text support is lame
+        labelType = (!nativeCanvasSupport || (textSupport && !iStuff)) ? 'Native' : 'HTML';
+        nativeTextSupport = labelType === 'Native';
+        useGradients = nativeCanvasSupport;
+        animate = !(iStuff || !nativeCanvasSupport);
+    }());
+
     var st = new $jit.ST({
         injectInto: 'jitTreeView',
         // id of viz container element
@@ -206,6 +230,10 @@ function initTreeView(jsonData) {
             align: 'center'
         },
 
+        Label: {
+            type: 'Native'
+        },
+
         Edge: {
             type: 'bezier',
             color: '#DCDFE4',
@@ -215,7 +243,8 @@ function initTreeView(jsonData) {
         // This method is called on DOM label creation.
         // Use this method to add event handlers and styles to
         // your node.
-        onCreateLabel: function (label, node) {
+        /*onCreateLabel: function (label, node) {
+            console.log(node);
             label.id = node.id;
             label.innerHTML = node.name;
             label.onclick = function () {
@@ -231,7 +260,7 @@ function initTreeView(jsonData) {
             style.fontSize = '0.8em';
             style.textAlign = 'center';
             style.paddingTop = '3px';
-        },
+        },*/
 
         // This method is called right before plotting
         // a node. It's useful for changing an individual node
@@ -275,7 +304,6 @@ function initTreeView(jsonData) {
     });
     // load json data
     st.loadJSON(jsonData);
-    console.log(jsonData);
 
     // compute node positions and layout
     st.compute();
@@ -283,10 +311,7 @@ function initTreeView(jsonData) {
     // optional: make a translation of the tree
     st.geom.translate(new $jit.Complex(-200, 0), "current");
 
-    st.onClick(jsonData.id);
-
-    // disable the text selection of tree nodes
-    $("#jitTreeView").disableSelection();
+    st.onClick(st.root);
 }
 
 function initTree(data, equate_il) {

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -401,19 +401,42 @@ function initTreeView(jsonData) {
       });
     }
 
+    // Expands a node and its children
+    function expand(d) {
+        if (d._children) {
+            d.children = d._children;
+            d._children = null;
+        }
+        if (d.children) {
+            d.children.forEach(function (c) {
+                if (c._children) {
+                    c.children = c._children;
+                    c._children = null;
+                }
+            });
+        }
+    }
+
+    // Collapses a node
+    function collapse(d) {
+        if (d.children) {
+            d._children = d.children;
+            d.children = null;
+        }
+    }
+
     // Toggle children on click.
     function click(d) {
       if (d.children) {
-        d._children = d.children;
-        d.children = null;
+        collapse(d);
       } else {
-        d.children = d._children;
-        d._children = null;
+        expand(d);
       }
       update(d);
       centerNode(d);
     }
 
+    // Sets the width of the right clicked node to 100%
     function rightClick(d) {
         // set Selection properties
         setSelected(root, false);
@@ -422,10 +445,7 @@ function initTreeView(jsonData) {
         // scale the lines
         widthScale.domain([0, d.data.count]);
 
-        if (d._children) {
-            d.children = d._children;
-            d._children = null;
-        }
+        expand(d);
 
         // redraw
         d3.event.preventDefault();

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -96,7 +96,7 @@ function init_multi(data, data2, equate_il) {
                 }
                 $("#d3TreeView svg").attr("width", width);
                 $("#d3TreeView svg").attr("height", height);
-                //$("#d3TreeView-tooltip").appendTo(destination);
+                $("#treeview-tooltip").appendTo(destination);
             }, 1000);
         }
     }
@@ -211,6 +211,14 @@ function initTreeView(jsonData) {
         duration = 750,
         root;
 
+    var tooltip = d3.select("body")
+        .append("div")
+        .attr("id", "treeview-tooltip")
+        .attr("class", "tip")
+        .style("position", "absolute")
+        .style("z-index", "10")
+        .style("visibility", "hidden");
+
     var tree = d3.layout.tree()
         .size([height, width]);
 
@@ -309,6 +317,8 @@ function initTreeView(jsonData) {
           .style("cursor", "pointer")
           .attr("transform", function(d) { return "translate(" + source.y0 + "," + source.x0 + ")"; })
           .on("click", click)
+          .on("mouseover", tooltipIn)
+          .on("mouseout", tooltipOut)
           .on("contextmenu",rightClick);
 
       nodeEnter.append("circle")
@@ -531,6 +541,25 @@ function initTreeView(jsonData) {
             .attr("transform", "translate(" + x + "," + y + ")scale(" + scale + ")");
         zoomListener.scale(scale);
         zoomListener.translate([x, y]);
+    }
+
+    // tooltip functions
+    function tooltipIn(d, i) {
+        tooltip.style("visibility", "visible")
+            .html("<b>" + d.name + "</b> (" + d.data.rank + ")<br/>" +
+                (!d.data.self_count ? "0" : d.data.self_count) +
+                (d.data.self_count && d.data.self_count === 1 ? " sequence" : " sequences") + " specific to this level<br/>" +
+                (!d.data.count ? "0" : d.data.count) +
+                (d.data.count && d.data.count === 1 ? " sequence" : " sequences") + " specific to this level or lower");
+            if (window.fullScreenApi.isFullScreen()) {
+                tooltip.style("top", (d3.event.clientY - 5) + "px").style("left", (d3.event.clientX + 15) + "px");
+            } else {
+                tooltip.style("top", (d3.event.pageY - 5) + "px").style("left", (d3.event.pageX + 15) + "px");
+            }
+
+    }
+    function tooltipOut(d, i) {
+        tooltip.style("visibility", "hidden");
     }
 }
 

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -106,15 +106,14 @@ function init_multi(data, data2, equate_il) {
     $("#save-btn").click(function () {
         $(".debug_dump").hide();
         if ($(".tab-content .active").attr('id') === "sunburstWrapper") {
-            // Track save image
             logToGoogle("Multi Peptide", "Save Image", "Sunburst");
-
             triggerDownloadModal("#sunburst svg", null, "unipept_sunburst");
-        } else {
-            // Track save image
+        } else if ($(".tab-content .active").attr('id') === "treeMapWrapper") {
             logToGoogle("Multi Peptide", "Save Image", "Treemap");
-
             triggerDownloadModal(null, "#treeMap", "unipept_treemap");
+        } else {
+            logToGoogle("Multi Peptide", "Save Image", "Treeview");
+            triggerDownloadModal("#d3TreeView svg", null, "unipept_treeview");
         }
     });
 }

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -291,9 +291,22 @@ function initTreeView(jsonData) {
 
       nodeEnter.append("circle")
           .attr("r", 1e-6)
-          .style("stroke", function (d) { return d.color || "#aaa";})
           .style("stroke-width", "1.5px")
-          .style("fill", function(d) { return d._children ? "lightsteelblue" : "#fff"; });
+          .style("stroke", function (d) {
+              if (d.selected) {
+                  return d.color || "#aaa";
+              } else {
+                  return "#aaa";
+              }
+          })
+          .style("fill", function(d) {
+              if (d.selected) {
+                  return d._children ? d.color || "#aaa" : "#fff";
+              } else {
+                  return "#aaa";
+              }
+
+          });
 
       nodeEnter.append("text")
           .attr("x", function(d) { return d.children || d._children ? -10 : 10; })
@@ -357,12 +370,16 @@ function initTreeView(jsonData) {
       link.enter().insert("path", "g")
           .attr("class", "link")
           .style("fill", "none")
-          .style("stroke", function (d) { return d.target.color; })
           .style("stroke-opacity", "0.5")
           .style("stroke-linecap", "round")
-          .style("stroke-width", function (d) {
-              return widthScale(d.target.data.count) + "px";
+          .style("stroke", function (d) {
+              if (d.source.selected) {
+                  return d.target.color;
+              } else {
+                  return "#aaa";
+              }
           })
+          .style("stroke-width", 1e-6)
           .attr("d", function (d) {
             var o = {x: source.x0, y: source.y0};
             return diagonal({source: o, target: o});
@@ -390,6 +407,7 @@ function initTreeView(jsonData) {
       // Transition exiting nodes to the parent's new position.
       link.exit().transition()
           .duration(duration)
+          .style("stroke-width", 1e-6)
           .attr("d", function(d) {
             var o = {x: source.x, y: source.y};
             return diagonal({source: o, target: o});

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -220,6 +220,9 @@ function initTreeView(jsonData) {
         root.y0 = 0;
 
         function collapse(d) {
+            if (d.children && d.children.length == 0) {
+                d.children = null;
+            }
             if (d.children) {
                 d._children = d.children;
                 d._children.forEach(collapse);

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -314,10 +314,15 @@ function initTreeView(jsonData) {
     st.onClick(st.root);
 }
 
+/**
+ * Zoomable treeview based on
+ * - http://bl.ocks.org/mbostock/4339083
+ * - https://gist.github.com/robschmuecker/7880033
+ */
 function initTreeView2(jsonData) {
-    var margin = {top: 20, right: 120, bottom: 20, left: 120},
-        width = 960 - margin.right - margin.left,
-        height = 800 - margin.top - margin.bottom;
+    var margin = {top: 5, right: 5, bottom: 5, left: 60},
+        width = 916 - margin.right - margin.left,
+        height = 600 - margin.top - margin.bottom;
 
     var i = 0,
         duration = 750,
@@ -329,11 +334,16 @@ function initTreeView2(jsonData) {
     var diagonal = d3.svg.diagonal()
         .projection(function(d) { return [d.y, d.x]; });
 
+    // define the zoomListener which calls the zoom function on the "zoom" event constrained within the scaleExtents
+    var zoomListener = d3.behavior.zoom().scaleExtent([0.1, 3]).on("zoom", zoom);
+
     var svg = d3.select("#d3TreeView").append("svg")
         .attr("width", width + margin.right + margin.left)
         .attr("height", height + margin.top + margin.bottom)
+        .call(zoomListener)
       .append("g")
-        .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+        .attr("transform", "translate(" + margin.left + "," + margin.top + ")")
+      .append("g");
 
     draw(jsonData)
 
@@ -460,6 +470,26 @@ function initTreeView2(jsonData) {
         d._children = null;
       }
       update(d);
+      centerNode(d);
+    }
+
+    // Zoom function
+    function zoom() {
+        svg.attr("transform", "translate(" + d3.event.translate + ")scale(" + d3.event.scale + ")");
+    }
+
+    // Center a node
+    function centerNode(source) {
+        var scale = zoomListener.scale(),
+            x = -source.y0,
+            y = -source.x0;
+        x = x * scale + width / 2;
+        y = y * scale + height / 2;
+        svg.transition()
+            .duration(duration)
+            .attr("transform", "translate(" + x + "," + y + ")scale(" + scale + ")");
+        zoomListener.scale(scale);
+        zoomListener.translate([x, y]);
     }
 }
 

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -292,17 +292,18 @@ function initTreeView(jsonData) {
         root.children.forEach( function (node) {color(node); });
 
         // collapse everything
-        function collapse(d) {
+        function collapseAll(d) {
             if (d.children && d.children.length == 0) {
                 d.children = null;
             }
             if (d.children) {
                 d._children = d.children;
-                d._children.forEach(collapse);
+                d._children.forEach(collapseAll);
                 d.children = null;
             }
         }
-        root.children.forEach(collapse);
+        collapseAll(root);
+        expand(root);
 
         update(root);
     };

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -225,7 +225,7 @@ function initTreeView(jsonData) {
                 d.color = c;
             } else if (d.name == "Bacteria") {
                 d.color = "#1f77b4"; // blue
-            } else if (d.name == "Archae") {
+            } else if (d.name == "Archaea") {
                 d.color = "#ff7f0e"; // orange
             } else if (d.name == "Eukaryota") {
                 d.color = "#2ca02c"; // green

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -214,7 +214,7 @@ function initTreeView(jsonData) {
     draw(jsonData)
 
     function draw(data) {
-        widthScale.domain([1, data.data.count]);
+        widthScale.domain([0, data.data.count]);
 
         root = data;
         root.x0 = height / 2;
@@ -420,7 +420,7 @@ function initTreeView(jsonData) {
         setSelected(d, true);
 
         // scale the lines
-        widthScale.domain([1, d.data.count]);
+        widthScale.domain([0, d.data.count]);
 
         if (d._children) {
             d.children = d._children;

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -179,25 +179,6 @@ function initTreeMap(jsonData) {
 }
 
 function initTreeView(jsonData) {
-    var labelType,
-        useGradients,
-        nativeTextSupport,
-        animate;
-
-    (function () {
-        var ua = navigator.userAgent,
-            iStuff = ua.match(/iPhone/i) || ua.match(/iPad/i),
-            typeOfCanvas = typeof HTMLCanvasElement,
-            nativeCanvasSupport = (typeOfCanvas === 'object' || typeOfCanvas === 'function'),
-            textSupport = nativeCanvasSupport && (typeof document.createElement('canvas').getContext('2d').fillText === 'function');
-        // I'm setting this based on the fact that ExCanvas provides text support for IE
-        // and that as of today iPhone/iPad current text support is lame
-        labelType = (!nativeCanvasSupport || (textSupport && !iStuff)) ? 'Native' : 'HTML';
-        nativeTextSupport = labelType === 'Native';
-        useGradients = nativeCanvasSupport;
-        animate = !(iStuff || !nativeCanvasSupport);
-    }());
-
     var st = new $jit.ST({
         injectInto: 'jitTreeView',
         // id of viz container element
@@ -238,6 +219,18 @@ function initTreeView(jsonData) {
             type: 'bezier',
             color: '#DCDFE4',
             overridable: true
+        },
+
+        Events: {
+            enable: true,
+            onClick: function (node) {
+                console.log(node);
+                /*if (node) {
+                    logToGoogle("Multi Peptide", "Zoom", "Treemap", "In");
+                    tm.enter(node);
+                    treeSearch(node.name, 500);
+                }*/
+            }
         },
 
         // This method is called on DOM label creation.

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -415,9 +415,19 @@ function initTreeView(jsonData) {
     }
 
     function rightClick(d) {
+        // set Selection properties
         setSelected(root, false);
         setSelected(d, true);
+
+        // scale the lines
         widthScale.domain([1, d.data.count]);
+
+        if (d._children) {
+            d.children = d._children;
+            d._children = null;
+        }
+
+        // redraw
         d3.event.preventDefault();
         update(d);
         centerNode(d);

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -188,6 +188,8 @@ function initTreeView(jsonData) {
         width = 916 - margin.right - margin.left,
         height = 600 - margin.top - margin.bottom;
 
+    var rightClicked;
+
     var i = 0,
         duration = 750,
         root;
@@ -438,6 +440,12 @@ function initTreeView(jsonData) {
 
     // Sets the width of the right clicked node to 100%
     function rightClick(d) {
+        if (d === rightClicked && d !== root) {
+            rightClick(root);
+            return;
+        }
+        rightClicked = d;
+
         // set Selection properties
         setSelected(root, false);
         setSelected(d, true);

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -219,6 +219,26 @@ function initTreeView(jsonData) {
         root.x0 = height / 2;
         root.y0 = 0;
 
+        // set colors
+        function color(d, c) {
+            if (c) {
+                d.color = c;
+            } else if (d.name == "Bacteria") {
+                d.color = "#1f77b4"; // blue
+            } else if (d.name == "Archae") {
+                d.color = "#ff7f0e"; // orange
+            } else if (d.name == "Eukaryota") {
+                d.color = "#2ca02c"; // green
+            } else if (d.name == "Viruses") {
+                d.color = "#d6616b"; // red
+            }
+            if (d.children) {
+                d.children.forEach( function (node) { color(node, d.color); });
+            }
+        }
+        root.children.forEach( function (node) {color(node); });
+
+        // collapse everything
         function collapse(d) {
             if (d.children && d.children.length == 0) {
                 d.children = null;
@@ -228,10 +248,10 @@ function initTreeView(jsonData) {
                 d._children.forEach(collapse);
                 d.children = null;
             }
-          }
+        }
+        root.children.forEach(collapse);
 
-          root.children.forEach(collapse);
-          update(root);
+        update(root);
     };
 
     d3.select(self.frameElement).style("height", "800px");
@@ -258,7 +278,7 @@ function initTreeView(jsonData) {
 
       nodeEnter.append("circle")
           .attr("r", 1e-6)
-          .style("stroke", "steelblue")
+          .style("stroke", function (d) { return d.color || "#aaa";})
           .style("stroke-width", "1.5px")
           .style("fill", function(d) { return d._children ? "lightsteelblue" : "#fff"; });
 
@@ -280,7 +300,7 @@ function initTreeView(jsonData) {
               return widthScale(d.data.count) / 2;
           })
           .style("fill-opacity", function(d) { return d._children ? 1 : 0; })
-          .style("fill", function(d) { return d._children ? "lightsteelblue" : "#fff"; });
+          .style("fill", function(d) { return d._children ? d.color : "#fff"; });
 
       nodeUpdate.select("text")
           .style("fill-opacity", 1);
@@ -305,7 +325,7 @@ function initTreeView(jsonData) {
       link.enter().insert("path", "g")
           .attr("class", "link")
           .style("fill", "none")
-          .style("stroke", "#aaa")
+          .style("stroke", function (d) { return d.target.color; })
           .style("stroke-opacity", "0.5")
           .style("stroke-linecap", "round")
           .style("stroke-width", function (d) {

--- a/app/assets/javascripts/multi_search.js
+++ b/app/assets/javascripts/multi_search.js
@@ -39,6 +39,13 @@ function init_multi(data, data2, equate_il) {
         error(err.message, "Loading the Treeview visualization failed. Please use Google Chrome, Firefox or Internet Explorer 9 or higher.");
     }
 
+    // treeview2
+    try {
+        initTreeView2(JSON.parse(JSON.stringify(data)));
+    } catch (err) {
+        error(err.message, "Loading the Treeview visualization failed. Please use Google Chrome, Firefox or Internet Explorer 9 or higher.");
+    }
+
     // tree
     try {
         initTree(data, equate_il);
@@ -305,6 +312,155 @@ function initTreeView(jsonData) {
     st.geom.translate(new $jit.Complex(-200, 0), "current");
 
     st.onClick(st.root);
+}
+
+function initTreeView2(jsonData) {
+    var margin = {top: 20, right: 120, bottom: 20, left: 120},
+        width = 960 - margin.right - margin.left,
+        height = 800 - margin.top - margin.bottom;
+
+    var i = 0,
+        duration = 750,
+        root;
+
+    var tree = d3.layout.tree()
+        .size([height, width]);
+
+    var diagonal = d3.svg.diagonal()
+        .projection(function(d) { return [d.y, d.x]; });
+
+    var svg = d3.select("#d3TreeView").append("svg")
+        .attr("width", width + margin.right + margin.left)
+        .attr("height", height + margin.top + margin.bottom)
+      .append("g")
+        .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+    draw(jsonData)
+
+    function draw(data) {
+      root = data;
+      root.x0 = height / 2;
+      root.y0 = 0;
+
+      function collapse(d) {
+        if (d.children) {
+          d._children = d.children;
+          d._children.forEach(collapse);
+          d.children = null;
+        }
+      }
+
+      root.children.forEach(collapse);
+      update(root);
+    };
+
+    d3.select(self.frameElement).style("height", "800px");
+
+    function update(source) {
+
+      // Compute the new tree layout.
+      var nodes = tree.nodes(root).reverse(),
+          links = tree.links(nodes);
+
+      // Normalize for fixed-depth.
+      nodes.forEach(function(d) { d.y = d.depth * 180; });
+
+      // Update the nodes…
+      var node = svg.selectAll("g.node")
+          .data(nodes, function(d) { return d.id || (d.id = ++i); });
+
+      // Enter any new nodes at the parent's previous position.
+      var nodeEnter = node.enter().append("g")
+          .attr("class", "node")
+          .style("cursor", "pointer")
+          .attr("transform", function(d) { return "translate(" + source.y0 + "," + source.x0 + ")"; })
+          .on("click", click);
+
+      nodeEnter.append("circle")
+          .attr("r", 1e-6)
+          .style("stroke", "steelblue")
+          .style("stroke-width", "1.5px")
+          .style("fill", function(d) { return d._children ? "lightsteelblue" : "#fff"; });
+
+      nodeEnter.append("text")
+          .attr("x", function(d) { return d.children || d._children ? -10 : 10; })
+          .attr("dy", ".35em")
+          .attr("text-anchor", function(d) { return d.children || d._children ? "end" : "start"; })
+          .text(function(d) { return d.name; })
+          .style("font", "10px sans-serif")
+          .style("fill-opacity", 1e-6);
+
+      // Transition nodes to their new position.
+      var nodeUpdate = node.transition()
+          .duration(duration)
+          .attr("transform", function(d) { return "translate(" + d.y + "," + d.x + ")"; });
+
+      nodeUpdate.select("circle")
+          .attr("r", 4.5)
+          .style("fill", function(d) { return d._children ? "lightsteelblue" : "#fff"; });
+
+      nodeUpdate.select("text")
+          .style("fill-opacity", 1);
+
+      // Transition exiting nodes to the parent's new position.
+      var nodeExit = node.exit().transition()
+          .duration(duration)
+          .attr("transform", function(d) { return "translate(" + source.y + "," + source.x + ")"; })
+          .remove();
+
+      nodeExit.select("circle")
+          .attr("r", 1e-6);
+
+      nodeExit.select("text")
+          .style("fill-opacity", 1e-6);
+
+      // Update the links…
+      var link = svg.selectAll("path.link")
+          .data(links, function(d) { return d.target.id; });
+
+      // Enter any new links at the parent's previous position.
+      link.enter().insert("path", "g")
+          .attr("class", "link")
+          .style("fill", "none")
+          .style("stroke", "#ccc")
+          .style("stroke-width", "1.5px")
+          .attr("d", function(d) {
+            var o = {x: source.x0, y: source.y0};
+            return diagonal({source: o, target: o});
+          });
+
+      // Transition links to their new position.
+      link.transition()
+          .duration(duration)
+          .attr("d", diagonal);
+
+      // Transition exiting nodes to the parent's new position.
+      link.exit().transition()
+          .duration(duration)
+          .attr("d", function(d) {
+            var o = {x: source.x, y: source.y};
+            return diagonal({source: o, target: o});
+          })
+          .remove();
+
+      // Stash the old positions for transition.
+      nodes.forEach(function(d) {
+        d.x0 = d.x;
+        d.y0 = d.y;
+      });
+    }
+
+    // Toggle children on click.
+    function click(d) {
+      if (d.children) {
+        d._children = d.children;
+        d.children = null;
+      } else {
+        d.children = d._children;
+        d._children = null;
+      }
+      update(d);
+    }
 }
 
 function initTree(data, equate_il) {

--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -483,6 +483,9 @@ span.dir {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+#d3TreeView {
+    background-color: white;
+}
 #multisearch_list ul {
     padding-top: 0px;
     padding-bottom: 0px;

--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -497,6 +497,11 @@ span.dir {
 .tip-title {
     text-align:center;
 }
+/* treeview */
+#jitTreeView {
+    width: 100%;
+    height: 600px;
+}
 /* tree */
 #tree_data {
     width: 450px;

--- a/app/views/sequences/multi_search.html.erb
+++ b/app/views/sequences/multi_search.html.erb
@@ -51,7 +51,7 @@
             <h2 class="ghead"><span class="dir">Add some help text here</span></h2>
             <div id="jitTreeView"></div>
         </div>
-        <div class="tab-pane active" id="d3TreeViewWrapper">
+        <div class="tab-pane" id="d3TreeViewWrapper">
             <h2 class="ghead"><span class="dir">Add some help text here</span></h2>
             <div id="d3TreeView"></div>
         </div>

--- a/app/views/sequences/multi_search.html.erb
+++ b/app/views/sequences/multi_search.html.erb
@@ -47,7 +47,7 @@
             <div id="treeMap"></div>
         </div>
         <div class="tab-pane" id="d3TreeViewWrapper">
-            <h2 class="ghead"><span class="dir">Scroll to zoom, drag to pan and click a node to expand</span></h2>
+            <h2 class="ghead"><span class="dir">Scroll to zoom, drag to pan, click a node to expand, right click a node to set as root</span></h2>
             <div id="d3TreeView"></div>
         </div>
     </div>

--- a/app/views/sequences/multi_search.html.erb
+++ b/app/views/sequences/multi_search.html.erb
@@ -25,8 +25,7 @@
     <ul class="nav nav-tabs" id="viz-tabs">
         <li class="active"><a href="#sunburstWrapper" data-toggle="tab">Sunburst</a></li>
         <li><a href="#treeMapWrapper" data-toggle="tab">Treemap</a></li>
-        <li><a href="#jitTreeViewWrapper" data-toggle="tab">Treeview</a></li>
-        <li><a href="#d3TreeViewWrapper" data-toggle="tab">Treeview2</a></li>
+        <li><a href="#d3TreeViewWrapper" data-toggle="tab">Treeview</a></li>
     </ul>
     <div class="tab-content multi-search">
         <div class="tab-pane active" id="sunburstWrapper">
@@ -47,12 +46,8 @@
             <h2 class="ghead"><span class="dir">Click a square to zoom in and right click to zoom out</span></h2>
             <div id="treeMap"></div>
         </div>
-        <div class="tab-pane active" id="jitTreeViewWrapper">
-            <h2 class="ghead"><span class="dir">Add some help text here</span></h2>
-            <div id="jitTreeView"></div>
-        </div>
         <div class="tab-pane" id="d3TreeViewWrapper">
-            <h2 class="ghead"><span class="dir">Add some help text here</span></h2>
+            <h2 class="ghead"><span class="dir">Scroll to zoom, drag to pan and click a node to expand</span></h2>
             <div id="d3TreeView"></div>
         </div>
     </div>

--- a/app/views/sequences/multi_search.html.erb
+++ b/app/views/sequences/multi_search.html.erb
@@ -25,6 +25,7 @@
     <ul class="nav nav-tabs" id="viz-tabs">
         <li class="active"><a href="#sunburstWrapper" data-toggle="tab">Sunburst</a></li>
         <li><a href="#treeMapWrapper" data-toggle="tab">Treemap</a></li>
+        <li><a href="#jitTreeViewWrapper" data-toggle="tab">Treeview</a></li>
     </ul>
     <div class="tab-content multi-search">
         <div class="tab-pane active" id="sunburstWrapper">
@@ -44,6 +45,10 @@
         <div class="tab-pane active" id="treeMapWrapper">
             <h2 class="ghead"><span class="dir">Click a square to zoom in and right click to zoom out</span></h2>
             <div id="treeMap"></div>
+        </div>
+        <div class="tab-pane active" id="jitTreeViewWrapper">
+            <h2 class="ghead"><span class="dir">Add some help text here</span></h2>
+            <div id="jitTreeView">bla</div>
         </div>
     </div>
 <% end %>

--- a/app/views/sequences/multi_search.html.erb
+++ b/app/views/sequences/multi_search.html.erb
@@ -26,6 +26,7 @@
         <li class="active"><a href="#sunburstWrapper" data-toggle="tab">Sunburst</a></li>
         <li><a href="#treeMapWrapper" data-toggle="tab">Treemap</a></li>
         <li><a href="#jitTreeViewWrapper" data-toggle="tab">Treeview</a></li>
+        <li><a href="#d3TreeViewWrapper" data-toggle="tab">Treeview2</a></li>
     </ul>
     <div class="tab-content multi-search">
         <div class="tab-pane active" id="sunburstWrapper">
@@ -49,6 +50,10 @@
         <div class="tab-pane active" id="jitTreeViewWrapper">
             <h2 class="ghead"><span class="dir">Add some help text here</span></h2>
             <div id="jitTreeView"></div>
+        </div>
+        <div class="tab-pane active" id="d3TreeViewWrapper">
+            <h2 class="ghead"><span class="dir">Add some help text here</span></h2>
+            <div id="d3TreeView"></div>
         </div>
     </div>
 <% end %>

--- a/app/views/sequences/multi_search.html.erb
+++ b/app/views/sequences/multi_search.html.erb
@@ -48,7 +48,7 @@
         </div>
         <div class="tab-pane active" id="jitTreeViewWrapper">
             <h2 class="ghead"><span class="dir">Add some help text here</span></h2>
-            <div id="jitTreeView">bla</div>
+            <div id="jitTreeView"></div>
         </div>
     </div>
 <% end %>


### PR DESCRIPTION
Closes #367 

There seem to be some issues with adding 2 jit visualisations to the same page. The rendering of the labels is bugged:
- the treemap labels are not shown
- the treeview labels are shown on the treemap

Switching the treeview to Native labels instead of HTML labels fixes this issue, but there's no event handling for Native labels which means no zooming.

One solution might be to implement a custom label type based on the HTML labels: https://github.com/philogb/jit/blob/master/Jit/jit.js#L7721

There's also an issue with the canvas rendering on hidpi displays: http://www.html5rocks.com/en/tutorials/canvas/hidpi/


_[Original pull request](https://github.ugent.be/unipept/unipept/pull/381) by @bmesuere on Sun Jun 15 2014 at 21:15._
_Merged by @bmesuere on Sun Jul 06 2014 at 12:04._