### PR TITLE
hotfix: replace biomart with PRIDE API

### DIFF
--- a/app/controllers/pride_controller.rb
+++ b/app/controllers/pride_controller.rb
@@ -1,7 +1,7 @@
 class PrideController < ApplicationController
   def load
-     response = HTTParty.get("http://www.biomart.org/biomart/martservice?query=%3C?xml%20version=%221.0%22%20encoding=%22UTF-8%22?%3E%3C!DOCTYPE%20Query%3E%3CQuery%20virtualSchemaName%20=%20%22default%22%20formatter%20=%20%22HTML%22%20header%20=%20%220%22%20uniqueRows%20=%20%220%22%20count%20=%20%22%22%20datasetConfigVersion%20=%20%220.6%22%20%3E%3CDataset%20name%20=%20%22pride%22%20interface%20=%20%22default%22%20%3E%3CFilter%20name%20=%20%22experiment_ac%22%20value%20=%20%22#{params[:id]}%22/%3E%3CAttribute%20name%20=%20%22peptide_sequence%22%20/%3E%3C/Dataset%3E%3C/Query%3E")
-     resp = response.body.lines.grep(/<td>/).join.gsub(/.*<td>(.*)<\/td>.*/,"\\1")
+     response = HTTParty.get("http://wwwdev.ebi.ac.uk:80/pride/ws/archive/peptide/list/assay/#{params[:id]}?show=9999999&page=0")
+     resp = JSON.parse(response.body)["list"].map{|e| e["sequence"]}.join("\n")
      render :plain => resp
   end
 end

--- a/app/controllers/pride_controller.rb
+++ b/app/controllers/pride_controller.rb
@@ -1,6 +1,6 @@
 class PrideController < ApplicationController
   def load
-     response = HTTParty.get("http://wwwdev.ebi.ac.uk:80/pride/ws/archive/peptide/list/assay/#{params[:id]}?show=9999999&page=0")
+     response = HTTParty.get("http://www.ebi.ac.uk:80/pride/ws/archive/peptide/list/assay/#{params[:id]}?show=9999999&page=0")
      resp = JSON.parse(response.body)["list"].map{|e| e["sequence"]}.join("\n")
      render :plain => resp
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,7 +54,7 @@ module UnipeptWeb
     config.assets.paths << "#{Rails}/vendor/assets/fonts"
 
     config.versions = {
-      :unipept => "2.4",
+      :unipept => "2.4.2",
       :gem => "0.5.7",
       :uniprot => "2014.05"
     }

--- a/test/controllers/pride_controller_test.rb
+++ b/test/controllers/pride_controller_test.rb
@@ -5,7 +5,7 @@ class PrideControllerTest < ActionController::TestCase
   test "should load PRIDE data" do
     get :load, {'id' => "8500"}
     assert_response :success
-    assert @response.body.start_with? "VVSVLTVLHQDWLNGK\nHYEGSTVPEKK"
+    assert @response.body.start_with? "ADSQAQLLLSTVVGVFTAPGLHLK\nAEEEHLGILGPQLHADVGDKVK\nAFWLDVSHNR"
   end
 
 end


### PR DESCRIPTION
The PRIDE BioMart will be retired by the end of this year. This PR replaces the BioMart API call with a similar PRIDE API call.

This can't be merged yet, because the API call we're using isn't in production yet. This should be the case by the end of november and can be checked at http://www.ebi.ac.uk/pride/ws/archive/.

There currently isn't a way to load all peptides at once, so we just use a very big number. The PRIDE people warned us about this:

> To get all results at once (although we would discourage this use), you
> have to use a high enough value or the value of the result count, which
> you can get with /peptide/count/assay.
> Although it might be possible to download all peptides at once, this is
> a much heavier operation than with the pages result. We did not have
> very good experiences with it. You may run into timeouts or our server
> into memory issues. If we notice that this kind of requests cause
> problems on our side, we may forbid them and set a maximum limit.

Since PRIDE has a proper API, we could do the call from JavaScript instead of using the unipept server as a proxy. (#434)


_[Original pull request](https://github.ugent.be/unipept/unipept/pull/433) by @bmesuere on Wed Nov 19 2014 at 13:39._
_Merged by @bmesuere on Mon Dec 01 2014 at 16:44._