### PR TITLE
run curls to uniprot in parallel

### DIFF
--- a/backend/proteomes.sh
+++ b/backend/proteomes.sh
@@ -7,13 +7,22 @@ proteome_gz_file="$1"
 type_strains="$2"
 outfile="$3"
 
-tmp="$(mktemp)"
+set -e
 
-zcat $proteome_gz_file | while read id accession; do
+tmp="$(mktemp)"
+echo "$tmp"
+
+get_proteome() {
+    local id="$1"
+    local accession="$2"
     curl -s http://www.uniprot.org/proteomes/$accession \
         | html2text -nobs -width 1000 \
         | awk -f proteomes.awk -v id=$id -v accession=$accession
-done > "$tmp"
+}
+# to reach it with the bash subprocess of xargs
+export -f get_proteome
+
+zcat $proteome_gz_file | xargs -P 10 -I{} bash -c 'get_proteome {}' > "$tmp"
 
 join -1 8 -2 1 -a 1 -t '	'                                         \
         <(sort -t'	' -k 8 "$tmp")                                    \


### PR DESCRIPTION
I was testing #555 and I had to wait too long for this last step. I used 10 processes for now, speed can still be increased in the future if required.


_[Original pull request](https://github.ugent.be/unipept/unipept/pull/556) by @ninewise on Thu Jan 28 2016 at 10:51._
_Merged by @ninewise on Mon Feb 01 2016 at 14:17._