### PR TITLE
WIP: Optimize the UniProt parser

### DIFF
--- a/backend/config
+++ b/backend/config
@@ -6,14 +6,11 @@ TABDIR=${DATADIR}/tables
 UNIDIR=${DATADIR}/uniprot
 TAXDIR=${DATADIR}/taxon
 INTDIR=${DATADIR}/intermediate
-BDBDIR=../../berkeleydb
 
-JMEMMIN='-Xms140g'
-JMEMMAX='-Xmx150g'
-BDBMEM='100000000000'
-#JMEMMIN='-Xms2g'
-#JMEMMAX='-Xmx3g'
-#BDBMEM=500000000
+#JMEMMIN='-Xms140g'
+#JMEMMAX='-Xmx150g'
+JMEMMIN='-Xms2g'
+JMEMMAX='-Xmx3g'
 
 TAXON_URL=ftp://ftp.ncbi.nih.gov/pub/taxonomy/taxdmp.zip
 UNIPROT_URL=ftp://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/

--- a/backend/config
+++ b/backend/config
@@ -12,6 +12,8 @@ INTDIR=${DATADIR}/intermediate
 JMEMMIN='-Xms2g'
 JMEMMAX='-Xmx3g'
 
+SORT=sort --buffer-size=80% --parallel=4
+
 TAXON_URL=ftp://ftp.ncbi.nih.gov/pub/taxonomy/taxdmp.zip
 UNIPROT_URL=ftp://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/
 ENTREZ_URL=http://eutils.ncbi.nlm.nih.gov/entrez/eutils

--- a/backend/config
+++ b/backend/config
@@ -1,6 +1,10 @@
 LOGFILE=main.log
 MAIL=unipept@ugent.be
 
+# Peptides minimum length
+PEPMIN=8
+PEPMAX=50
+
 DATADIR=../../data
 TABDIR=${DATADIR}/tables
 UNIDIR=${DATADIR}/uniprot

--- a/backend/config
+++ b/backend/config
@@ -11,10 +11,8 @@ UNIDIR=${DATADIR}/uniprot
 TAXDIR=${DATADIR}/taxon
 INTDIR=${DATADIR}/intermediate
 
-#JMEMMIN='-Xms140g'
-#JMEMMAX='-Xmx150g'
-JMEMMIN='-Xms2g'
-JMEMMAX='-Xmx3g'
+JMEMMIN='-Xms5g'
+JMEMMAX='-Xmx6g'
 
 SORT=LC_ALL=C sort --buffer-size=80% --parallel=4
 GZIP=gzip

--- a/backend/config
+++ b/backend/config
@@ -12,7 +12,8 @@ INTDIR=${DATADIR}/intermediate
 JMEMMIN='-Xms2g'
 JMEMMAX='-Xmx3g'
 
-SORT=sort --buffer-size=80% --parallel=4
+SORT=LC_ALL=C sort --buffer-size=80% --parallel=4
+GZIP=gzip
 
 TAXON_URL=ftp://ftp.ncbi.nih.gov/pub/taxonomy/taxdmp.zip
 UNIPROT_URL=ftp://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/

--- a/backend/makefile
+++ b/backend/makefile
@@ -163,7 +163,7 @@ $(INTDIR)/original_LCAs.tsv.gz: $(TABDIR)/lineages.tsv.gz $(INTDIR)/original_seq
 	echo "Starting the calculation non-equalized LCA's."
 	java $(JMEMMIN) $(JMEMMAX) -cp $(JAR) $(PAC).LineagesSequencesTaxons2LCAs \
 		<(zcat $(TABDIR)/lineages.tsv.gz) \
-		<(zcat $(INTDIR)/sequence_taxon.tsv.gz) \
+		<(zcat $(INTDIR)/original_sequence_taxon.tsv.gz) \
 		>($(GZIP) - > $(INTDIR)/original_LCAs.tsv.gz)
 	echo "Finished the calculation non-equalized LCA's."
 

--- a/backend/makefile
+++ b/backend/makefile
@@ -71,8 +71,10 @@ $(TABLES): $(TABDIR)/taxons.tsv.gz $(UNIDIR)/uniprot_sprot.xml.gz
 	#$(UNIDIR)/uniprot_trembl.xml.gz
 	echo "Started calculation of most tables."
 	mkdir -p $(INTDIR)
-	java $(JMEMMIN) $(JMEMMAX) -cp $(JAR) $(PAC).TaxonsUniprots2Tables           \
-		--taxons          <(zcat $(TABDIR)/taxons.tsv.gz)                        \
+	java $(JMEMMIN) $(JMEMMAX) -cp $(JAR) $(PAC).TaxonsUniprots2Tables              \
+		--peptide-min     $(PEPMIN)                                                 \
+		--peptide-max     $(PEPMAX)                                                 \
+		--taxons          <(zcat $(TABDIR)/taxons.tsv.gz)                           \
 		--peptides        >($(GZIP) - > $(INTDIR)/peptides.tsv.gz)                  \
 		--uniprot-entries >($(GZIP) - > $(TABDIR)/uniprot_entries.tsv.gz)           \
 		--refseq          >($(GZIP) - > $(TABDIR)/refseq_cross_references.tsv.gz)   \

--- a/backend/makefile
+++ b/backend/makefile
@@ -79,7 +79,7 @@ $(INTDIR)/aa_sequence_taxon.tsv.gz: $(INTDIR)/peptides.tsv.gz $(TABDIR)/uniprot_
 	join -t '	' -o '1.2,2.2' -j 1 \
 			<(zcat $(INTDIR)/peptides.tsv.gz | awk '{ printf("%020d\t%s\n", $$4, $$2) }') \
 			<(zcat $(TABDIR)/uniprot_entries.tsv.gz | awk '{ printf("%020d\t%s\n", $$1, $$4) }') \
-		| sort -S 20% -k1 \
+		| $(SORT) -k1 \
 		| gzip - \
 		> $@
 	echo "Finished the joining of equalized peptides and uniprot entries."
@@ -90,14 +90,14 @@ $(INTDIR)/original_aa_sequence_taxon.tsv.gz: $(INTDIR)/peptides.tsv.gz $(TABDIR)
 	join -t '	' -o '1.2,2.2' -j 1 \
 			<(zcat $(INTDIR)/peptides.tsv.gz | awk '{ printf("%020d\t%s\n", $$4, $$3) }') \
 			<(zcat $(TABDIR)/uniprot_entries.tsv.gz | awk '{ printf("%020d\t%s\n", $$1, $$4) }') \
-		| sort -S 20% -k1 \
+		| $(SORT) -k1 \
 		| gzip - \
 		> $@
 	echo "Finished the joining of non-equalized peptides and uniprot entries."
 
 $(INTDIR)/sequences.tsv.gz: $(INTDIR)/aa_sequence_taxon.tsv.gz $(INTDIR)/original_aa_sequence_taxon.tsv.gz
 	echo "Starting the numbering of sequences."
-	sort -m \
+	$(SORT) -m \
 			<(zcat $(INTDIR)/aa_sequence_taxon.tsv.gz | cut -f1) \
 			<(zcat $(INTDIR)/original_aa_sequence_taxon.tsv.gz | cut -f1) \
 		| uniq \
@@ -110,11 +110,11 @@ $(INTDIR)/sequences.tsv.gz: $(INTDIR)/aa_sequence_taxon.tsv.gz $(INTDIR)/origina
 $(TABDIR)/peptides.tsv.gz: $(INTDIR)/peptides.tsv.gz $(INTDIR)/sequences.tsv.gz
 	echo "Starting the substitution of AA's by ID's for the peptides."
 	zcat $(INTDIR)/peptides.tsv.gz \
-		| sort -k 2b,2 \
+		| $(SORT) -k 2b,2 \
 		| join -t '	' -o '1.1,2.1,1.3,1.4' -1 2 -2 2 - <(zcat $(INTDIR)/sequences.tsv.gz) \
-		| sort -k 3b,3 \
+		| $(SORT) -k 3b,3 \
 		| join -t '	' -o '1.1,1.2,2.1,1.4' -1 3 -2 2 - <(zcat $(INTDIR)/sequences.tsv.gz) \
-		| sort -n \
+		| $(SORT) -n \
 		| gzip - \
 		> $@
 	echo "Finishing the substitution of AA's by ID's for the peptides."

--- a/backend/makefile
+++ b/backend/makefile
@@ -91,8 +91,8 @@ $(INTDIR)/aa_sequence_taxon.tsv.gz: $(INTDIR)/peptides.tsv.gz $(TABDIR)/uniprot_
 	echo "Starting the joining of equalized peptides and uniprot entries."
 	mkdir -p $(INTDIR)
 	join -t '	' -o '1.2,2.2' -j 1 \
-			<(zcat $(INTDIR)/peptides.tsv.gz | awk '{ printf("%020d\t%s\n", $$4, $$2) }') \
-			<(zcat $(TABDIR)/uniprot_entries.tsv.gz | awk '{ printf("%020d\t%s\n", $$1, $$4) }') \
+			<(zcat $(INTDIR)/peptides.tsv.gz | awk '{ printf("%012d\t%s\n", $$4, $$2) }') \
+			<(zcat $(TABDIR)/uniprot_entries.tsv.gz | awk '{ printf("%012d\t%s\n", $$1, $$4) }') \
 		| $(SORT) -k1 \
 		| $(GZIP) - \
 		> $@
@@ -102,8 +102,8 @@ $(INTDIR)/original_aa_sequence_taxon.tsv.gz: $(INTDIR)/peptides.tsv.gz $(TABDIR)
 	echo "Starting the joining of non-equalized peptides and uniprot entries."
 	mkdir -p $(INTDIR)
 	join -t '	' -o '1.2,2.2' -j 1 \
-			<(zcat $(INTDIR)/peptides.tsv.gz | awk '{ printf("%020d\t%s\n", $$4, $$3) }') \
-			<(zcat $(TABDIR)/uniprot_entries.tsv.gz | awk '{ printf("%020d\t%s\n", $$1, $$4) }') \
+			<(zcat $(INTDIR)/peptides.tsv.gz | awk '{ printf("%012d\t%s\n", $$4, $$3) }') \
+			<(zcat $(TABDIR)/uniprot_entries.tsv.gz | awk '{ printf("%012d\t%s\n", $$1, $$4) }') \
 		| $(SORT) -k1 \
 		| $(GZIP) - \
 		> $@

--- a/backend/makefile
+++ b/backend/makefile
@@ -67,8 +67,8 @@ $(TABLES): $(TABDIR)/taxons.tsv.gz $(UNIDIR)/uniprot_sprot.xml.gz
 	#$(UNIDIR)/uniprot_trembl.xml.gz
 	echo "Started calculation of most tables."
 	mkdir -p $(INTDIR)
-	java $(JMEMMIN) $(JMEMMAX) -cp $(JAR) $(PAC).TaxonsUniprots2Tables $(TABDIR)/taxons.tsv.gz $(TABLES) $(UNIDIR)/uniprot_sprot.xml.gz "swissprot"
-	#java $(JMEMMIN) $(JMEMMAX) -cp $(JAR) $(PAC).TaxonsUniprots2Tables $(TABDIR)/taxons.tsv.gz $(TABLES) $(UNIDIR)/uniprot_sprot.xml.gz "swissprot" $(UNIDIR)/uniprot_trembl.xml.gz "trembl"
+	java $(JMEMMIN) $(JMEMMAX) -cp $(JAR) $(PAC).TaxonsUniprots2Tables $(TABDIR)/taxons.tsv.gz $(TABLES) <(zcat $(UNIDIR)/uniprot_sprot.xml.gz) "swissprot"
+	#java $(JMEMMIN) $(JMEMMAX) -cp $(JAR) $(PAC).TaxonsUniprots2Tables $(TABDIR)/taxons.tsv.gz $(TABLES) <(zcat $(UNIDIR)/uniprot_sprot.xml.gz) "swissprot" <(zcat $(UNIDIR)/uniprot_trembl.xml.gz) "trembl"
 	echo "Finished calculation of most tables."
 # }}}
 

--- a/backend/makefile
+++ b/backend/makefile
@@ -62,13 +62,25 @@ $(TABDIR)/taxons.tsv.gz $(TABDIR)/lineages.tsv.gz: $(TAXDIR)/names.dmp $(TAXDIR)
 	echo "Finished calculation of taxons and lineages tables."
 # }}}
 
+TABLES=                                        \
+	$(INTDIR)/peptides.tsv.gz                  \
 # Uniprot entries, peptides, sequences and cross references {{{ ----------------
 $(TABLES): $(TABDIR)/taxons.tsv.gz $(UNIDIR)/uniprot_sprot.xml.gz
 	#$(UNIDIR)/uniprot_trembl.xml.gz
 	echo "Started calculation of most tables."
 	mkdir -p $(INTDIR)
-	java $(JMEMMIN) $(JMEMMAX) -cp $(JAR) $(PAC).TaxonsUniprots2Tables $(TABDIR)/taxons.tsv.gz $(TABLES) <(zcat $(UNIDIR)/uniprot_sprot.xml.gz) "swissprot"
-	#java $(JMEMMIN) $(JMEMMAX) -cp $(JAR) $(PAC).TaxonsUniprots2Tables $(TABDIR)/taxons.tsv.gz $(TABLES) <(zcat $(UNIDIR)/uniprot_sprot.xml.gz) "swissprot" <(zcat $(UNIDIR)/uniprot_trembl.xml.gz) "trembl"
+	java $(JMEMMIN) $(JMEMMAX) -cp $(JAR) $(PAC).TaxonsUniprots2Tables           \
+		--taxons          <(zcat $(TABDIR)/taxons.tsv.gz)                        \
+		--peptides        >(gzip - > $(INTDIR)/peptides.tsv.gz)                  \
+		--uniprot-entries >(gzip - > $(TABDIR)/uniprot_entries.tsv.gz)           \
+		--refseq          >(gzip - > $(TABDIR)/refseq_cross_references.tsv.gz)   \
+		--ec              >(gzip - > $(TABDIR)/ec_cross_references.tsv.gz)       \
+		--embl            >(gzip - > $(TABDIR)/embl_cross_references.tsv.gz)     \
+		--go              >(gzip - > $(TABDIR)/go_cross_references.tsv.gz)       \
+		--proteomes       >(gzip - > $(INTDIR)/proteomes.tsv.gz)                 \
+		--proteomes-ref   >(gzip - > $(TABDIR)/proteome_cross_references.tsv.gz) \
+		swissprot=<(zcat $(UNIDIR)/uniprot_sprot.xml.gz)
+	#trembl=<(zcat $(UNIDIR)/uniprot_trembl.xml.gz)
 	echo "Finished calculation of most tables."
 # }}}
 

--- a/backend/makefile
+++ b/backend/makefile
@@ -97,10 +97,9 @@ $(INTDIR)/original_aa_sequence_taxon.tsv.gz: $(INTDIR)/peptides.tsv.gz $(TABDIR)
 
 $(INTDIR)/sequences.tsv.gz: $(INTDIR)/aa_sequence_taxon.tsv.gz $(INTDIR)/original_aa_sequence_taxon.tsv.gz
 	echo "Starting the numbering of sequences."
-	cat \
+	sort -m \
 			<(zcat $(INTDIR)/aa_sequence_taxon.tsv.gz | cut -f1) \
 			<(zcat $(INTDIR)/original_aa_sequence_taxon.tsv.gz | cut -f1) \
-		| sort -S 20% \
 		| uniq \
 		| cat -n \
 		| sed 's/^ *//' \
@@ -112,11 +111,10 @@ $(TABDIR)/peptides.tsv.gz: $(INTDIR)/peptides.tsv.gz $(INTDIR)/sequences.tsv.gz
 	echo "Starting the substitution of AA's by ID's for the peptides."
 	zcat $(INTDIR)/peptides.tsv.gz \
 		| sort -k 2b,2 \
-		| tee >(head >&2) \
 		| join -t '	' -o '1.1,2.1,1.3,1.4' -1 2 -2 2 - <(zcat $(INTDIR)/sequences.tsv.gz) \
 		| sort -k 3b,3 \
-		| tee >(head >&2) \
 		| join -t '	' -o '1.1,1.2,2.1,1.4' -1 3 -2 2 - <(zcat $(INTDIR)/sequences.tsv.gz) \
+		| sort -n \
 		| gzip - \
 		> $@
 	echo "Finishing the substitution of AA's by ID's for the peptides."

--- a/backend/makefile
+++ b/backend/makefile
@@ -83,8 +83,7 @@ $(TABLES): $(TABDIR)/taxons.tsv.gz $(UNIDIR)/uniprot_sprot.xml.gz
 		--go              >($(GZIP) - > $(TABDIR)/go_cross_references.tsv.gz)       \
 		--proteomes       >($(GZIP) - > $(INTDIR)/proteomes.tsv.gz)                 \
 		--proteomes-ref   >($(GZIP) - > $(TABDIR)/proteome_cross_references.tsv.gz) \
-		swissprot=<(zcat $(UNIDIR)/uniprot_sprot.xml.gz)
-	#trembl=<(zcat $(UNIDIR)/uniprot_trembl.xml.gz)
+		swissprot=<(zcat $(UNIDIR)/uniprot_sprot.xml.gz) trembl=<(zcat $(UNIDIR)/uniprot_trembl.xml.gz)
 	echo "Finished calculation of most tables."
 # }}}
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -73,11 +73,6 @@
             <artifactId>junit</artifactId>
             <version>4.11</version>
         </dependency>
-        <dependency>
-            <groupId>com.sleepycat</groupId>
-            <artifactId>je</artifactId>
-            <version>3.3.75</version>
-        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -73,6 +73,11 @@
             <artifactId>junit</artifactId>
             <version>4.11</version>
         </dependency>
+        <dependency>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+            <version>1.48</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/backend/src/main/java/org/unipept/storage/CSV.java
+++ b/backend/src/main/java/org/unipept/storage/CSV.java
@@ -20,9 +20,7 @@ public class CSV {
         public Reader(String file) throws IOException {
             buffer = new BufferedReader(
                 new InputStreamReader(
-                    new GZIPInputStream(
-                        new FileInputStream(file)
-                    )
+                    new FileInputStream(file)
                 )
             );
         }
@@ -44,9 +42,7 @@ public class CSV {
         public Writer(String file) throws IOException {
             buffer = new BufferedWriter(
                 new OutputStreamWriter(
-                    new GZIPOutputStream(
-                        new FileOutputStream(file)
-                    )
+                    new FileOutputStream(file)
                 ), MB4
             );
         }

--- a/backend/src/main/java/org/unipept/storage/CSV.java
+++ b/backend/src/main/java/org/unipept/storage/CSV.java
@@ -12,6 +12,8 @@ import java.io.FileOutputStream;
 
 public class CSV {
 
+    private static final int MB4 = 4194304;
+
     public static class Reader {
         private BufferedReader buffer;
 
@@ -45,7 +47,7 @@ public class CSV {
                     new GZIPOutputStream(
                         new FileOutputStream(file)
                     )
-                )
+                ), MB4
             );
         }
 

--- a/backend/src/main/java/org/unipept/storage/TableWriter.java
+++ b/backend/src/main/java/org/unipept/storage/TableWriter.java
@@ -8,14 +8,6 @@ import java.io.IOException;
 import java.io.File;
 import java.sql.Timestamp;
 
-import com.sleepycat.je.Database;
-import com.sleepycat.je.DatabaseConfig;
-import com.sleepycat.je.Environment;
-import com.sleepycat.je.EnvironmentConfig;
-import com.sleepycat.collections.StoredMap;
-import com.sleepycat.bind.tuple.StringBinding;
-import com.sleepycat.bind.tuple.IntegerBinding;
-
 import org.unipept.xml.*;
 import org.unipept.storage.CSV;
 import org.unipept.taxons.TaxonList;

--- a/backend/src/main/java/org/unipept/storage/TableWriter.java
+++ b/backend/src/main/java/org/unipept/storage/TableWriter.java
@@ -81,8 +81,9 @@ public class TableWriter implements UniprotObserver {
         int uniprotEntryId = addUniprotEntry(entry.getUniprotAccessionNumber(), entry.getVersion(),
                 entry.getTaxonId(), entry.getType(), entry.getName(), entry.getSequence());
         if (uniprotEntryId != -1) { // failed to add entry
-            entry.digest().forEach(sequence ->
-                    addData(sequence.replace("I", "L"), uniprotEntryId, sequence));
+            for(String sequence : entry.digest()) {
+                addData(sequence.replace('I', 'L'), uniprotEntryId, sequence);
+            }
             for (UniprotDbRef ref : entry.getDbReferences())
                 addDbRef(ref, uniprotEntryId);
             for (UniprotGORef ref : entry.getGOReferences())

--- a/backend/src/main/java/org/unipept/storage/TableWriter.java
+++ b/backend/src/main/java/org/unipept/storage/TableWriter.java
@@ -11,6 +11,7 @@ import java.sql.Timestamp;
 import org.unipept.xml.*;
 import org.unipept.storage.CSV;
 import org.unipept.taxons.TaxonList;
+import org.unipept.tools.TaxonsUniprots2Tables;
 
 /**
  * Intermediate class to add PeptideData to the database
@@ -47,21 +48,21 @@ public class TableWriter implements UniprotObserver {
     /**
      * Creates a new data object
      */
-    public TableWriter(TaxonList taxonList, String peptidesFile, String uniprotEntriesFile, String refseqCrossReferencesFile, String ecCrossReferencesFile, String emblCrossReferencesFile, String goCrossReferencesFile, String proteomesFile, String proteomeCrossReferencesFile) {
+    public TableWriter(TaxonsUniprots2Tables args) {
         wrongTaxonIds = new HashSet<Integer>();
         proteomeIds = new HashMap<>();
-        this.taxonList = taxonList;
 
         /* Opening CSV files for writing. */
         try {
-            peptides = new CSV.IndexedWriter(peptidesFile);
-            proteomes = new CSV.IndexedWriter(proteomesFile);
-            uniprotEntries = new CSV.IndexedWriter(uniprotEntriesFile);
-            refseqCrossReferences = new CSV.IndexedWriter(refseqCrossReferencesFile);
-            ecCrossReferences = new CSV.IndexedWriter(ecCrossReferencesFile);
-            emblCrossReferences = new CSV.IndexedWriter(emblCrossReferencesFile);
-            goCrossReferences = new CSV.IndexedWriter(goCrossReferencesFile);
-            proteomeCrossReferences = new CSV.IndexedWriter(proteomeCrossReferencesFile);
+            taxonList = TaxonList.loadFromFile(args.taxonsFile);
+            peptides = new CSV.IndexedWriter(args.peptidesFile);
+            proteomes = new CSV.IndexedWriter(args.proteomesFile);
+            uniprotEntries = new CSV.IndexedWriter(args.uniprotEntriesFile);
+            refseqCrossReferences = new CSV.IndexedWriter(args.refseqCrossReferencesFile);
+            ecCrossReferences = new CSV.IndexedWriter(args.ecCrossReferencesFile);
+            emblCrossReferences = new CSV.IndexedWriter(args.emblCrossReferencesFile);
+            goCrossReferences = new CSV.IndexedWriter(args.goCrossReferencesFile);
+            proteomeCrossReferences = new CSV.IndexedWriter(args.proteomeCrossReferencesFile);
         } catch(IOException e) {
             System.err.println(new Timestamp(System.currentTimeMillis())
                     + " Error creating tsv files");

--- a/backend/src/main/java/org/unipept/tools/LineagesSequencesTaxons2LCAs.java
+++ b/backend/src/main/java/org/unipept/tools/LineagesSequencesTaxons2LCAs.java
@@ -7,8 +7,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.regex.Pattern;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 public class LineagesSequencesTaxons2LCAs {
 
@@ -22,13 +20,13 @@ public class LineagesSequencesTaxons2LCAs {
     private final Writer writer;
 
     public LineagesSequencesTaxons2LCAs(String taxonomyFile, String outputFile) throws IOException {
-        writer = new BufferedWriter(new OutputStreamWriter(new GZIPOutputStream(new FileOutputStream(outputFile)), "utf-8"));
+        writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outputFile), "utf-8"));
         buildTaxonomy(taxonomyFile);
     }
 
     private void buildTaxonomy(String file) throws FileNotFoundException, IOException {
         HashMap<Integer, int[]> taxonomyMap = new HashMap<>();
-        InputStream is = new GZIPInputStream(new FileInputStream(new File(file)));
+        InputStream is = new FileInputStream(new File(file));
         BufferedReader br = new BufferedReader(new InputStreamReader(is));
 
         br.lines()
@@ -51,7 +49,7 @@ public class LineagesSequencesTaxons2LCAs {
 
     public void calculateLCAs(String file) throws IOException {
         counter = 0;
-        BufferedReader br = new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(file))), 67108864);
+        BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file)), 67108864);
 
         int count = 0;
         int currentSequence = -1;

--- a/backend/src/main/java/org/unipept/tools/NamesNodes2Taxons.java
+++ b/backend/src/main/java/org/unipept/tools/NamesNodes2Taxons.java
@@ -3,9 +3,16 @@ package org.unipept.tools;
 import java.io.IOException;
 import java.io.FileNotFoundException;
 
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.JCommander;
+
 import org.unipept.taxons.TaxonList;
 
 public class NamesNodes2Taxons {
+
+    @Parameter(names="--names", description="Taxon names input file") public String namesFile;
+    @Parameter(names="--nodes", description="Taxon nodes input file") public String nodesFile;
+    @Parameter(names="--taxons", description="Taxon TSV output file") public String taxonsFile;
 
     /**
      * Parse a list of taxons from the NCBI dumps.
@@ -16,17 +23,12 @@ public class NamesNodes2Taxons {
      * be overwritten with a tsv-dump of the taxons table.
      */
     public static void main(String[] args) throws IOException {
-        if(args.length != 3) {
-            throw new RuntimeException("Please provide the parameters.");
-        }
+        NamesNodes2Taxons main = new NamesNodes2Taxons();
+        new JCommander(main, args);
 
-        String namesFile = args[0];
-        String nodesFile = args[1];
-        String taxonsFile = args[2];
-
-        TaxonList tl = TaxonList.parseDumps(namesFile, nodesFile);
+        TaxonList tl = TaxonList.parseDumps(main.namesFile, main.nodesFile);
         tl.invalidate();
-        tl.writeToFile(taxonsFile);
+        tl.writeToFile(main.taxonsFile);
     }
 
 }

--- a/backend/src/main/java/org/unipept/tools/NamesNodes2TaxonsLineages.java
+++ b/backend/src/main/java/org/unipept/tools/NamesNodes2TaxonsLineages.java
@@ -3,9 +3,17 @@ package org.unipept.tools;
 import java.io.IOException;
 import java.io.FileNotFoundException;
 
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.JCommander;
+
 import org.unipept.taxons.TaxonList;
 
 public class NamesNodes2TaxonsLineages {
+
+    @Parameter(names="--names", description="Taxon names input file") public String namesFile;
+    @Parameter(names="--nodes", description="Taxon nodes input file") public String nodesFile;
+    @Parameter(names="--taxons", description="Taxon TSV output file") public String taxonsFile;
+    @Parameter(names="--lineages", description="Lineages TSV output file") public String lineagesFile;
 
     /**
      * Parse a list of taxons and their lineages from the NCBI dumps.
@@ -16,19 +24,13 @@ public class NamesNodes2TaxonsLineages {
      * will be written to the third and fourth parameter.
      */
     public static void main(String[] args) throws IOException {
-        if(args.length != 4) {
-            throw new RuntimeException("Please provide the parameters.");
-        }
+        NamesNodes2TaxonsLineages main = new NamesNodes2TaxonsLineages();
+        new JCommander(main, args);
 
-        String namesFile = args[0];
-        String nodesFile = args[1];
-        String taxonsFile = args[2];
-        String lineagesFile = args[3];
-
-        TaxonList tl = TaxonList.parseDumps(namesFile, nodesFile);
+        TaxonList tl = TaxonList.parseDumps(main.namesFile, main.nodesFile);
         tl.invalidate();
-        tl.writeToFile(taxonsFile);
-        tl.writeLineagesToFile(lineagesFile);
+        tl.writeToFile(main.taxonsFile);
+        tl.writeLineagesToFile(main.lineagesFile);
     }
 
 }

--- a/backend/src/main/java/org/unipept/tools/TaxonsUniprots2Tables.java
+++ b/backend/src/main/java/org/unipept/tools/TaxonsUniprots2Tables.java
@@ -24,6 +24,8 @@ import org.unipept.storage.TableWriter;
 public class TaxonsUniprots2Tables {
 
     @Parameter(                           description="Files to be parsed")                   public List<String> files  = new ArrayList<>();
+    @Parameter(names="--peptide-min",    description="Minimum peptide length")               public int peptideMin;
+    @Parameter(names="--peptide-max",    description="Maximum peptide length")               public int peptideMax;
     @Parameter(names="--taxons",          description="Taxons TSV input file")                public String taxonsFile;
     @Parameter(names="--peptides",        description="Peptides TSV output file")             public String peptidesFile;
     @Parameter(names="--uniprot-entries", description="Uniprot entries TSV output file")      public String uniprotEntriesFile;
@@ -60,7 +62,7 @@ public class TaxonsUniprots2Tables {
             String uniprotFile = inputfile.split("=")[1];
             String uniprotType = inputfile.split("=")[0];
             InputStream uniprotStream = new FileInputStream(uniprotFile);
-            UniprotHandler handler = new UniprotHandler(uniprotType);
+            UniprotHandler handler = new UniprotHandler(main.peptideMin, main.peptideMax, uniprotType);
             handler.addObserver(writer);
             parser.parse(uniprotStream, handler);
             uniprotStream.close();

--- a/backend/src/main/java/org/unipept/tools/TaxonsUniprots2Tables.java
+++ b/backend/src/main/java/org/unipept/tools/TaxonsUniprots2Tables.java
@@ -34,16 +34,13 @@ public class TaxonsUniprots2Tables {
      */
     public static void main(String[] args) throws SAXException,
            ParserConfigurationException, FileNotFoundException, IOException {
-        if(args.length < 10) {
+        if(args.length < 9) {
             throw new RuntimeException("Please provide the parameters.");
         }
 
         int i = 0;
-        String berkeleyDir = args[i++];
-        long berkeleyMem = Long.parseLong(args[i++]);
         String taxonsFile = args[i++];
         String peptidesFile = args[i++];
-        String sequencesFile = args[i++];
         String uniprotEntriesFile = args[i++];
         String refseqCrossReferencesFile = args[i++];
         String ecCrossReferencesFile = args[i++];
@@ -53,11 +50,11 @@ public class TaxonsUniprots2Tables {
         String proteomeCrossReferencesFile = args[i++];
 
         TaxonList taxonList = TaxonList.loadFromFile(taxonsFile);
-        TableWriter writer = new TableWriter(berkeleyDir, berkeleyMem,
-            taxonList, peptidesFile, sequencesFile,
-            uniprotEntriesFile, refseqCrossReferencesFile,
-            ecCrossReferencesFile, emblCrossReferencesFile,
-            goCrossReferencesFile, proteomesFile, proteomeCrossReferencesFile
+        TableWriter writer = new TableWriter(taxonList, peptidesFile,
+                uniprotEntriesFile, refseqCrossReferencesFile,
+                ecCrossReferencesFile, emblCrossReferencesFile,
+                goCrossReferencesFile, proteomesFile,
+                proteomeCrossReferencesFile
         );
         SAXParser parser = SAXParserFactory.newInstance().newSAXParser();
 

--- a/backend/src/main/java/org/unipept/tools/TaxonsUniprots2Tables.java
+++ b/backend/src/main/java/org/unipept/tools/TaxonsUniprots2Tables.java
@@ -21,16 +21,15 @@ public class TaxonsUniprots2Tables {
     /**
      * Parse the uniprot xml files into TSV tables.
      *
-     * The first parameter is the name of an existing directory, which will be
-     * used to store a temporary database. The second parameter is a taxon file, as written by NamesNodes2Taxons. The
-     * next 7 parameters are the output files, all in TSV format. In order, they
-     * are: the peptides, the sequences, the uniprot entries, the RefSeq cross
-     * references, the EC cross references, the EMBL cross references and the GO
-     * cross references.
+     * The first parameter is a taxon file, as written by NamesNodes2Taxons. The
+     * next 8 parameters are the output files, all in TSV format. In order, they
+     * are: the peptides, the uniprot entries, the RefSeq cross,references, the 
+     * EC cross references, the EMBL cross references, the GO cross references,
+     * the proteomes and the proteome cross references.
      *
      * The rest of the parameters comes in pairs. Each pair is a uniprot xml
      * file to parse and the "type" the entries parsed from this file should get
-     * in the uniprot entries output. The number of pairs is arbitrary.
+     * in the UniProt entries output. The number of pairs is flexible.
      */
     public static void main(String[] args) throws SAXException,
            ParserConfigurationException, FileNotFoundException, IOException {

--- a/backend/src/main/java/org/unipept/tools/TaxonsUniprots2Tables.java
+++ b/backend/src/main/java/org/unipept/tools/TaxonsUniprots2Tables.java
@@ -61,9 +61,7 @@ public class TaxonsUniprots2Tables {
         for(; i < args.length; i += 2) {
             String uniprotFile = args[i];
             String uniprotType = args[i+1];
-            InputStream uniprotStream = new GZIPInputStream(
-                new FileInputStream(uniprotFile)
-            );
+            InputStream uniprotStream = new FileInputStream(uniprotFile);
             UniprotHandler handler = new UniprotHandler(uniprotType);
             handler.addObserver(writer);
             parser.parse(uniprotStream, handler);

--- a/backend/src/main/java/org/unipept/xml/UniprotEntry.java
+++ b/backend/src/main/java/org/unipept/xml/UniprotEntry.java
@@ -26,6 +26,7 @@ public class UniprotEntry {
     private List<UniprotGORef> goReferences;
     private List<UniprotECRef> ecReferences;
     private List<UniprotProteomeRef> protReferences;
+    private List<String> sequences;
 
     public UniprotEntry(String type) {
         this.type = type;
@@ -33,6 +34,7 @@ public class UniprotEntry {
         goReferences = new ArrayList<UniprotGORef>();
         ecReferences = new ArrayList<UniprotECRef>();
         protReferences = new ArrayList<UniprotProteomeRef>();
+        sequences = new ArrayList<String>();
     }
 
     public void reset(String type) {
@@ -47,6 +49,7 @@ public class UniprotEntry {
         goReferences.clear();
         ecReferences.clear();
         protReferences.clear();
+        sequences.clear();
     }
 
     public String getUniprotAccessionNumber() {
@@ -121,13 +124,23 @@ public class UniprotEntry {
         protReferences.add(ref);
     }
 
-    public Stream<String> digest() {
-        String[] splitArray = sequence.replaceAll("([RK])([^P])", "$1,$2")
-                                      .replaceAll("([RK])([^P,])", "$1,$2")
-                                      .split(",");
-        return Arrays.stream(splitArray)
-                     .filter(seq -> seq.length() >= MIN_PEPT_SIZE
-                                 && seq.length() <= MAX_PEPT_SIZE);
+    public List<String> digest() {
+        sequences.clear();
+        int start = 0;
+        int length = sequence.length();
+        for (int i = 0; i < length; i++) {
+            char x = sequence.charAt(i);
+            if ((x == 'K' || x == 'R') && (i + 1 < length && sequence.charAt(i + 1) != 'P')) {
+                if (i + 1 - start >= MIN_PEPT_SIZE && i + 1 - start <= MAX_PEPT_SIZE) {
+                    sequences.add(sequence.substring(start, i + 1));
+                }
+                start = i + 1;
+            }
+        }
+        if (length - start >= MIN_PEPT_SIZE && length - start <= MAX_PEPT_SIZE) {
+            sequences.add(sequence.substring(start, length));
+        }
+        return sequences;
     }
 
     public List<UniprotDbRef> getDbReferences() {

--- a/backend/src/main/java/org/unipept/xml/UniprotEntry.java
+++ b/backend/src/main/java/org/unipept/xml/UniprotEntry.java
@@ -12,8 +12,8 @@ import java.util.stream.Stream;
 public class UniprotEntry {
 
     // peptide settings
-    private static final int MIN_PEPT_SIZE = 5;
-    private static final int MAX_PEPT_SIZE = 50;
+    private final int peptideMin;
+    private final int peptideMax;
 
     private String uniprotAccessionNumber;
     private int version;
@@ -28,8 +28,10 @@ public class UniprotEntry {
     private List<UniprotProteomeRef> protReferences;
     private List<String> sequences;
 
-    public UniprotEntry(String type) {
+    public UniprotEntry(String type, int peptideMin, int peptideMax) {
         this.type = type;
+        this.peptideMin = peptideMin;
+        this.peptideMax = peptideMax;
         dbReferences = new ArrayList<UniprotDbRef>();
         goReferences = new ArrayList<UniprotGORef>();
         ecReferences = new ArrayList<UniprotECRef>();
@@ -131,13 +133,13 @@ public class UniprotEntry {
         for (int i = 0; i < length; i++) {
             char x = sequence.charAt(i);
             if ((x == 'K' || x == 'R') && (i + 1 < length && sequence.charAt(i + 1) != 'P')) {
-                if (i + 1 - start >= MIN_PEPT_SIZE && i + 1 - start <= MAX_PEPT_SIZE) {
+                if (i + 1 - start >= peptideMin && i + 1 - start <= peptideMax) {
                     sequences.add(sequence.substring(start, i + 1));
                 }
                 start = i + 1;
             }
         }
-        if (length - start >= MIN_PEPT_SIZE && length - start <= MAX_PEPT_SIZE) {
+        if (length - start >= peptideMin && length - start <= peptideMax) {
             sequences.add(sequence.substring(start, length));
         }
         return sequences;

--- a/backend/src/main/java/org/unipept/xml/UniprotHandler.java
+++ b/backend/src/main/java/org/unipept/xml/UniprotHandler.java
@@ -30,10 +30,10 @@ public class UniprotHandler extends DefaultHandler {
     private Map<String, EndTagWorker> endTagWorkers;
     private Map<String, StartTagWorker> startTagWorkers;
 
-    public UniprotHandler(String uniprotType) {
+    public UniprotHandler(int peptideMinLength, int peptideMaxLength, String uniprotType) {
         super();
         this.uniprotType = uniprotType;
-        currentItem = new UniprotEntry(uniprotType);
+        currentItem = new UniprotEntry(uniprotType, peptideMinLength, peptideMaxLength);
         charData = new StringBuilder();
         observers = new ArrayList<UniprotObserver>();
         i = 0;

--- a/backend/src/test/java/org/unipept/xml/UniprotHandlerTest.java
+++ b/backend/src/test/java/org/unipept/xml/UniprotHandlerTest.java
@@ -31,7 +31,7 @@ public class UniprotHandlerTest extends Assert {
     @Test
     public void testHandlerSwissProt_1() {
         Stats s = new Stats();
-        runHandler(new UniprotHandler("swissprot"), s, "../../../uniprot_sprot_1.xml");
+        runHandler(new UniprotHandler(5, 50, "swissprot"), s, "../../../uniprot_sprot_1.xml");
         assertEquals(s.entries, 1);
         assertEquals(s.sequences, 1);
     }
@@ -39,7 +39,7 @@ public class UniprotHandlerTest extends Assert {
     @Test
     public void testHandlerSwissProt_3() {
         Stats s = new Stats();
-        runHandler(new UniprotHandler("swissprot"), s, "../../../uniprot_sprot_3.xml");
+        runHandler(new UniprotHandler(5, 50, "swissprot"), s, "../../../uniprot_sprot_3.xml");
         assertEquals(s.entries, 3);
         assertEquals(s.sequences, 3);
     }


### PR DESCRIPTION
This PR contains several optimizations of the UniProt processing pipeline:
- stop using BerkeleyDB and assign sequence id's during post processing (also reduces memory requirements)
- custom protein digest
- use the unix gzip tools instead of gzip readers and writers in java
- smaller java tweaks
- using `LC_ALL=C` for the sort command increases performance by an order of magnitude
- use more memory and threads for the sort command

| &nbsp; | parse xml | join peptide uniprot | number sequences | sequence id | LCA calculation | join sequences | peptides id | **total** |
| :-- | --: | --: | --: | --: | --: | --: | --: | --: |
| initial code | 9h06m | 1h56m | - | - | 2 \* 50m | - | - | **12h42m** |
| without BDB | 5h30m | 2 \* 1h38 | 22m | 2 \* 19m | 2 \* 50m | 21m | 2h46 | **14h33m** |
| better digest | 2h53m | 2 \* 1h38 | 22m | 2 \* 19m | 2 \* 50m | 21m | 2h46 | **11h51m** |
| pigz & LC_ALL=C & s/20/12/ | 1h12m | 2 \* 52m | 15m | 2 \* 19m | 2 \* 41m | 12m | 1h44m | **7h22m** |
| threads | 1h18m | 2 \* 52m | 16m | 2 \* 19m | 2 \* 43m | 12m | 1h43m | **7h01m** |


_[Original pull request](https://github.ugent.be/unipept/unipept/pull/562) by @ninewise on Fri Feb 19 2016 at 10:45._
_Merged by @ninewise on Tue Apr 19 2016 at 14:18._