### PR TITLE
add option to download proteins to the unique peptide finder

### DIFF
--- a/app/assets/javascripts/peptidome/pancoreGraph.js
+++ b/app/assets/javascripts/peptidome/pancoreGraph.js
@@ -203,6 +203,8 @@ var constructPancoreGraph = function constructPancoreGraph(args) {
             "<li><a href='#' data-id='" + d.id + "' data-type='pan'><span style='color: " + panColor + ";'>&#9632;</span> pan peptidome</a></li>" +
             "<li><a href='#' data-id='" + d.id + "' data-type='core'><span style='color: " + coreColor + ";'>&#9632;</span> core peptidome</a></li>" +
             "<li><a href='#' data-id='" + d.id + "' data-type='unique'><span style='color: " + unicoreColor + ";'>&#9632;</span> unique peptidome</a></li>" +
+            "<li role='separator' class='divider'></li>" +
+            "<li><a href='#' data-id='" + d.id + "' data-type='unique_proteins'><span style='color: " + unicoreColor + ";'>&#9632;</span> unique peptidome proteins</a></li>" +
           "</ul>" +
         "</div>" +
         "<span class='pull-right'><a class='btn btn-danger' title='remove proteome' id='popover-remove-genome'data-id='" + d.id + "'><span class='glyphicon glyphicon-trash'></span></a></span>" +
@@ -516,7 +518,13 @@ var constructPancoreGraph = function constructPancoreGraph(args) {
         $("#download-peptides-toggle").button('loading');
         pancore.requestSequences(id, type)
             .then(function (data) {
-                return downloadDataByForm(data.sequences, data.type + '-sequences.txt');
+                var name = data.type + '-sequences';
+                var format = "txt";
+                if (data.type === "unique_proteins") {
+                    name = "unique-proteins";
+                    format = "csv";
+                }
+                return downloadDataByForm(data.sequences, name + '.' + format);
             })
             .then(function enableButton() {
                 $("#download-peptides-toggle").button('reset');

--- a/app/assets/javascripts/workers/pancore_worker.js
+++ b/app/assets/javascripts/workers/pancore_worker.js
@@ -738,7 +738,8 @@ function clearAllData() {
 // Sends a list sequences to the client
 function getSequences(type, id) {
     var ids,
-        ord = getOrderById(id);
+        ord = getOrderById(id),
+        action = "full_sequences";
     switch (type) {
     case 'all':
         ids = data[id].peptide_list;
@@ -752,10 +753,16 @@ function getSequences(type, id) {
     case 'unique':
         ids = unicores[ord];
         break;
+    case 'unique_proteins':
+        ids = unicores[ord];
+        break;
     default:
         error("Unknown type: " + type);
     }
-    getJSONByPost("/peptidome/full_sequences/", "sequence_ids=[" + deltaEncode(ids) + "]", function (d) {
+    if (type === "unique_proteins") {
+        action = "full_proteins";
+    }
+    getJSONByPost("/peptidome/" + action + "/", "sequence_ids=[" + deltaEncode(ids) + "]", function (d) {
         sendToHost("processDownloadedSequences", {sequences : d, type : type, id : id});
     });
 }

--- a/app/controllers/peptidome_controller.rb
+++ b/app/controllers/peptidome_controller.rb
@@ -51,7 +51,7 @@ class PeptidomeController < ApplicationController
   def get_proteins
     ids = ProteomeCache.delta_decode(JSON(params[:sequence_ids]))
     sequences = Sequence.includes(original_peptides: :uniprot_entry).where(id: ids)
-    data = Hash[sequences.map { |sequence| [sequence, sequence.original_peptides.map(&:uniprot_entry)] }]
+    data = sequences.map { |sequence| [sequence, sequence.original_peptides.map(&:uniprot_entry)] }
     csv_string = CSV.generate_line %w(sequence lca_taxon_id uniprot_id protein_name)
     data.each do |sequence, proteins|
       proteins.each do |uniprot_entry|

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,7 +56,7 @@ module UnipeptWeb
     config.versions = {
       unipept: '3.1.3',
       gem: '1.1.0',
-      uniprot: '2016.02'
+      uniprot: '2016.05'
     }
 
     config.api_host = 'api.unipept.ugent.be'

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,7 +54,7 @@ module UnipeptWeb
     config.assets.paths << "#{Rails}/vendor/assets/fonts"
 
     config.versions = {
-      unipept: '3.1.2',
+      unipept: '3.1.3',
       gem: '1.1.0',
       uniprot: '2016.02'
     }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ UnipeptWeb::Application.routes.draw do
   match '/peptidome/sequences/:proteome_id.:format', via: [:get, :post], :to => 'peptidome#get_sequence_ids_for_proteome', :constraints => { :proteome_id => /[0-z\._]+/ }
   match '/peptidome/unique_sequences', via: [:get, :post], :to => 'peptidome#get_unique_sequences'
   match '/peptidome/full_sequences', via: [:get, :post], :to => 'peptidome#get_sequences'
+  match '/peptidome/full_proteins', via: [:get, :post], :to => 'peptidome#get_proteins'
   match '/peptidome/convert_peptides', via: [:get, :post], :to => 'peptidome#convert_peptides'
   match '/peptidome/get_lca', via: [:get, :post], :to => 'peptidome#get_lca'
   get '/peptidome', :to => 'peptidome#analyze', :as => 'pancore_analyze'

--- a/test/controllers/peptidome_controller_test.rb
+++ b/test/controllers/peptidome_controller_test.rb
@@ -58,6 +58,12 @@ class PeptidomeControllerTest < ActionController::TestCase
     assert_equal '"AALER\nAAIER"', @response.body
   end
 
+  test 'should get get_proteins' do
+    get :get_proteins, sequence_ids: '[1, 1]'
+    assert_response :success
+    assert_equal '"sequence,lca_taxon_id,uniprot_id,protein_name\nAALER,2,nr2,some name\nAAIER,2,nr,some name\n"', @response.body
+  end
+
   test 'should get convert_peptides' do
     get :convert_peptides, peptides: '["AALER", "AAIER", "FOO"]'
     assert_response :success


### PR DESCRIPTION
To accommodate a reviewer request, adds an option to download protein information from the unique peptide finder page:

![image](https://github.ugent.be/storage/user/7/files/69abd35c-2c24-11e6-8647-49cc39e72631)

The resulting data is saved as a csv file:

```
sequence,lca_taxon_id,uniprot_id,protein_name
AAAAYVR,1358,Q9CDY4,50S ribosomal protein L17
AAAAYVR,1358,Q02W52,50S ribosomal protein L17
AAAAYVR,1358,A2RNM6,50S ribosomal protein L17
AAADELGVPLYNYLGGFNAK,1358,Q9CHS7,Enolase 1
AAADELGVPLYNYLGGFNAK,1358,A2RIX1,Enolase
AAADELGVPLYNYLGGFNAK,1358,Q030Y9,Enolase 2
...
```


_[Original pull request](https://github.ugent.be/unipept/unipept/pull/576) by @bmesuere on Mon Jun 06 2016 at 20:23._
_Merged by @bmesuere on Wed Jun 08 2016 at 18:41._