### PR TITLE
quickfix: wrong batch size variable

### DIFF
--- a/backend/type_strains.sh.in
+++ b/backend/type_strains.sh.in
@@ -24,9 +24,9 @@ web_env="$(echo "$header"                                         \
          | <<<CMD_SED>>> -n 's/.*<WebEnv>\(.*\)<\/WebEnv>.*/\1/p' \
          )"
 
-returned="$BATCH_SIZE"
+returned="$ENTREZ_BATCH_SIZE"
 retstart='1'
-while ((returned == BATCH_SIZE)); do
+while ((returned == ENTREZ_BATCH_SIZE)); do
     returned="$(curl -d 'db=assembly'                                 \
                      -d "query_key=$query_key"                        \
                      -d "WebEnv=$web_env"                             \


### PR DESCRIPTION
Using the wrong variable name resulted in only the first batch of type strains to be fetched.


_[Original pull request](https://github.ugent.be/unipept/unipept/pull/578) by @ninewise on Fri Jun 10 2016 at 11:39._
_Merged by @ninewise on Fri Jun 10 2016 at 13:04._