### PR TITLE
migrate to clipboard.js

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,7 +30,6 @@
         "$": false,
         "html2canvas": false,
         "_gaq": false,
-        "addCopy": false,
         "fullScreenApi": false,
         "delay": false,
         "Bloodhound": false,

--- a/Gemfile
+++ b/Gemfile
@@ -25,9 +25,6 @@ gem 'devise', '>= 3.5'
 gem 'devise_cas_authenticatable'
 gem 'responders', '>= 2.0'
 
-# zeroclipboard
-gem 'zeroclipboard-rails'
-
 # needed for asset creation
 gem 'therubyracer'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,8 +291,6 @@ GEM
     will_paginate (3.1.6)
     xpath (2.1.0)
       nokogiri (~> 1.3)
-    zeroclipboard-rails (0.1.2)
-      railties (>= 3.1)
 
 PLATFORMS
   ruby
@@ -338,7 +336,6 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webpacker
   will_paginate
-  zeroclipboard-rails
 
 BUNDLED WITH
    1.13.7

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,47 +3,9 @@
 // yarn deps
 //= require typeahead.js/dist/typeahead.bundle.js
 
-//= require zeroclipboard
 //= require vendor
 
 //= require_self
-
-// zeroclipboard config
-ZeroClipboard.config({
-    hoverClass: 'btn-clipboard-hover'
-});
-
-function addCopy(selector, textFunction, tooltip) {
-    var copyMissed = new ZeroClipboard(selector);
-    var htmlBridge = $('#global-zeroclipboard-html-bridge');
-    copyMissed.on('ready', function () {
-        htmlBridge
-          .data('placement', 'top')
-          .attr('title', tooltip || 'Copy to clipboard')
-          .tooltip();
-    });
-    // Copy to clipboard
-    copyMissed.on('copy', function (client) {
-        copyMissed.setText(textFunction.call());
-    });
-    // Notify copy success and reset tooltip title
-    copyMissed.on('aftercopy', function () {
-        htmlBridge
-          .attr('title', 'Copied!')
-          .tooltip('fixTitle')
-          .tooltip('show')
-          .attr('title', 'Copy to clipboard')
-          .tooltip('fixTitle');
-    });
-    // Notify copy failure
-    copyMissed.on('error', function (e) {
-        selector.first()
-          .data('placement', 'top')
-          .attr('title', 'Flash is required')
-          .tooltip('fixTitle')
-          .tooltip("show");
-    });
-}
 
 /**
  * Capitalizes the first letter of a string

--- a/app/assets/javascripts/multisearch/multisearch.js
+++ b/app/assets/javascripts/multisearch/multisearch.js
@@ -1,5 +1,5 @@
 import {showNotification} from "../notifications.js";
-import {logToGoogle, showError, triggerDownloadModal} from "../utils.js";
+import {addCopy, logToGoogle, showError, triggerDownloadModal} from "../utils.js";
 
 import {constructSearchtree} from "./searchtree.js";
 import {constructSunburst} from "./sunburst.js";
@@ -50,9 +50,7 @@ function initMultisearch(args) {
         // set up missed
         addMissed();
         // copy to clipboard for missed peptides
-        addCopy($("#copy-missed span").first(), function () {
-            return $(".mismatches").text();
-        });
+        addCopy("#copy-missed span", () => $(".mismatches").text());
     }
 
     function initVisualisations() {

--- a/app/assets/javascripts/multisearch/searchtree.js
+++ b/app/assets/javascripts/multisearch/searchtree.js
@@ -139,7 +139,7 @@ function constructSearchtree(args) {
             }
             stringBuffer += "</ul>";
             infoPane.append(stringBuffer);
-            infoPane.find("h4.own").before("<div id='copy-own' class='zero-clipboard'><span class='btn-clipboard'>Copy</span></div>");
+            infoPane.find("h4.own").before("<div id='copy-own' class='clipboard-btn-wrapper'><span class='btn-clipboard'>Copy</span></div>");
             addCopy("#copy-own span", () => ownSequences.join("\n"));
         }
         allSequences = multi.getAllSequences(d).sort();
@@ -150,7 +150,7 @@ function constructSearchtree(args) {
             }
             stringBuffer += "</ul>";
             infoPane.append(stringBuffer);
-            infoPane.find("h4.all").before("<div id='copy-all' class='zero-clipboard'><span class='btn-clipboard'>Copy</span></div>");
+            infoPane.find("h4.all").before("<div id='copy-all' class='clipboard-btn-wrapper'><span class='btn-clipboard'>Copy</span></div>");
             addCopy("#copy-all span", () => allSequences.join("\n"));
         }
         return false;

--- a/app/assets/javascripts/multisearch/searchtree.js
+++ b/app/assets/javascripts/multisearch/searchtree.js
@@ -1,4 +1,4 @@
-import {highlight, logToGoogle} from "../utils.js";
+import {addCopy, highlight, logToGoogle} from "../utils.js";
 
 /**
  * Constructs a Searchtree object
@@ -140,9 +140,7 @@ function constructSearchtree(args) {
             stringBuffer += "</ul>";
             infoPane.append(stringBuffer);
             infoPane.find("h4.own").before("<div id='copy-own' class='zero-clipboard'><span class='btn-clipboard'>Copy</span></div>");
-            addCopy($("#copy-own span").first(), function () {
-                return ownSequences.join("\n");
-            });
+            addCopy("#copy-own span", () => ownSequences.join("\n"));
         }
         allSequences = multi.getAllSequences(d).sort();
         if (allSequences && allSequences.length > 0 && allSequences.length !== (ownSequences ? ownSequences.length : 0)) {
@@ -153,9 +151,7 @@ function constructSearchtree(args) {
             stringBuffer += "</ul>";
             infoPane.append(stringBuffer);
             infoPane.find("h4.all").before("<div id='copy-all' class='zero-clipboard'><span class='btn-clipboard'>Copy</span></div>");
-            addCopy($("#copy-all span").first(), function () {
-                return allSequences.join("\n");
-            });
+            addCopy("#copy-all span", () => allSequences.join("\n"));
         }
         return false;
     }

--- a/app/assets/javascripts/sequence_show.js
+++ b/app/assets/javascripts/sequence_show.js
@@ -1,4 +1,4 @@
-import {logToGoogle, triggerDownloadModal} from "./utils.js";
+import {addCopy, logToGoogle, triggerDownloadModal} from "./utils.js";
 import {showInfoModal} from "./modal.js";
 
 function initSequenceShow(data) {
@@ -64,9 +64,7 @@ function initSequenceShow(data) {
             url += entries.join("+OR+accession%3A");
             window.open(url, "_blank");
         });
-        addCopy($("#clipboard-uniprot").first(), function () {
-            return entries.join("\n");
-        }, "Copy UniProt IDs to clipboard");
+        addCopy("#clipboard-uniprot", () => entries.join("\n"), "Copy UniProt IDs to clipboard");
     }
 
     /**

--- a/app/assets/javascripts/utils.js
+++ b/app/assets/javascripts/utils.js
@@ -1,3 +1,28 @@
+import Clipboard from "clipboard";
+
+function addCopy(selector, textFunction, tooltip = "Copy to clipboard") {
+    const $el = $(selector).data("placement", "top")
+        .attr("title", tooltip)
+        .tooltip();
+    const clip = new Clipboard(selector, {
+        text: textFunction,
+    });
+    clip.on("success", e => {
+        $el.attr("title", "Copied!")
+            .tooltip("fixTitle")
+            .tooltip("show")
+            .attr("title", tooltip)
+            .tooltip("fixTitle");
+    });
+    clip.on("error", e => {
+        $el.attr("title", "Sorry, something went wrong")
+            .tooltip("fixTitle")
+            .tooltip("show")
+            .attr("title", tooltip)
+            .tooltip("fixTitle");
+    });
+}
+
 /*
  * Returns the brightness of an rgb-color
  * from: http:// www.w3.org/WAI/ER/WD-AERT/#color-contrast
@@ -247,4 +272,4 @@ function triggerDownloadModal(svgSelector, canvasSelector, baseFileName) {
     }
 }
 
-export {brightness, downloadDataByForm, downloadDataByLink, get, getJSON, getReadableColorFor, highlight, iteratorToArray, logErrorToGoogle, logToGoogle, showError, showInfo, stringHash, triggerDownloadModal};
+export {addCopy, brightness, downloadDataByForm, downloadDataByLink, get, getJSON, getReadableColorFor, highlight, iteratorToArray, logErrorToGoogle, logToGoogle, showError, showInfo, stringHash, triggerDownloadModal};

--- a/app/assets/stylesheets/utilities.css.less
+++ b/app/assets/stylesheets/utilities.css.less
@@ -73,8 +73,8 @@
     margin-right: 20px;
 }
 
-// Zero clipboard
-.zero-clipboard {
+// clipboard
+.clipboard-btn-wrapper {
     position: relative;
     display: block;
 }

--- a/app/views/sequences/multi_search.html.erb
+++ b/app/views/sequences/multi_search.html.erb
@@ -123,7 +123,7 @@
               </ul>
             </div>
             <div class="col-md-6">
-              <div id="copy-missed" class="zero-clipboard"><span class="btn-clipboard">Copy</span></div>
+              <div id="copy-missed" class="clipboard-btn-wrapper"><span class="btn-clipboard">Copy</span></div>
               <div class="well">
                 <h3>Sorry,</h3>
                 <p>We didn't manage to find some of your peptides. You can <strong><span class="initialism">BLAST</span></strong> them by clicking the links on the left or <strong>copy</strong> them to your clipboard with the top right link.</p>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.6.0",
+    "clipboard": "^1.7.1",
     "coffee-loader": "^0.7.3",
     "coffee-script": "^1.12.6",
     "compression-webpack-plugin": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,6 +1062,14 @@ cli-width@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
 
+clipboard@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.7.1.tgz#360d6d6946e99a7a1fef395e42ba92b5e9b5a16b"
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -1539,6 +1547,10 @@ del@^3.0.0:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+
+delegate@^3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.1.3.tgz#9a8251a777d7025faa55737bc3b071742127a9fd"
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -2246,6 +2258,12 @@ gonzales-pe@^4.0.3:
   resolved "https://registry.yarnpkg.com/gonzales-pe/-/gonzales-pe-4.0.3.tgz#36148e18e267184fbfdc929af28f29ad9fbf9746"
   dependencies:
     minimist "1.1.x"
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  dependencies:
+    delegate "^3.1.2"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
@@ -4517,6 +4535,10 @@ select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
 
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+
 selfsigned@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.9.1.tgz#cdda4492d70d486570f87c65546023558e1dfa5a"
@@ -4958,6 +4980,10 @@ timers-browserify@^2.0.2:
 tiny-emitter@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.0.tgz#bad327adb1804b42a231afa741532bd884cd09ad"
+
+tiny-emitter@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.1.tgz#e65919d91e488e2a78f7ebe827a56c6b188d51af"
 
 tmp@^0.0.31:
   version "0.0.31"


### PR DESCRIPTION
Replace the flash based zero clipboard by a javascript solution.

closes #529 
fixes #559 


_[Original pull request](https://github.ugent.be/unipept/unipept/pull/615) by @bmesuere on Thu Aug 17 2017 at 10:52._
_Merged by @bmesuere on Thu Aug 17 2017 at 14:45._