### PR TITLE
Update the command line docs

### DIFF
--- a/app/controllers/api/clidocs_controller.rb
+++ b/app/controllers/api/clidocs_controller.rb
@@ -42,6 +42,7 @@ class Api::ClidocsController < ApplicationController
   def pept2prot
     @title = 'The unipept pept2prot command'
     @sidebar_name = 'unipept pept2prot'
+    @sidebar_subnav << 'Meganize'
   end
 
   def pept2taxa

--- a/app/views/api/clidocs/_getting_started.html.erb
+++ b/app/views/api/clidocs/_getting_started.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class='card-supporting-text'>
     <p>
-      Before the Unipept command line interface (<span class='initialism'>CLI</span>) can be used, it first needs to be <a href='<%= api_clidocs_path %>#installation' target='_blank'>installed locally</a>. Since the commands of the <span class='initialism'>CLI</span> are implemented in Ruby, <a href='https://www.ruby-lang.org/en/downloads/' target='_blank'>the Ruby environment must be installed first</a> (at least version 1.9). The Unipept <span class='initialism'>CLI</span> can then be installed using the <code>gem</code> command, which is the RubyGems package manager for the Ruby programming language.
+      Before the Unipept command line interface (<span class='initialism'>CLI</span>) can be used, it first needs to be <a href='<%= api_clidocs_path %>#installation' target='_blank'>installed locally</a>. Since the commands of the <span class='initialism'>CLI</span> are implemented in Ruby, <a href='https://www.ruby-lang.org/en/downloads/' target='_blank'>the Ruby environment must be installed first</a> (at least version 2.0). The Unipept <span class='initialism'>CLI</span> can then be installed using the <code>gem</code> command, which is the RubyGems package manager for the Ruby programming language.
     </p>
     <pre>
 <b>$</b> gem install unipept

--- a/app/views/api/clidocs/index.html.erb
+++ b/app/views/api/clidocs/index.html.erb
@@ -38,13 +38,13 @@
         </div>
         <div class='card-supporting-text'>
     <p>
-      To use the Unipept command line tools, Ruby needs to be installed on your system. We recommend using Ruby 2.2, but all versions since Ruby 1.9.3, as well as JRuby are supported. To check if you have the correct Ruby version installed, open a terminal and run
+      To use the Unipept command line tools, Ruby needs to be installed on your system. We recommend using Ruby 2.4, but all versions since Ruby 2.0.0, as well as JRuby are supported. To check if you have the correct Ruby version installed, open a terminal and run
       <code>ruby --version</code>.
     </p>
 
     <pre>
 <b>$</b> ruby --version
-ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin14]</pre>
+ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-darwin16]</pre>
 
     <div class="apidocs-callout apidocs-callout-info">
       <h4>Installing Ruby</h4>

--- a/app/views/api/clidocs/pept2prot.html.erb
+++ b/app/views/api/clidocs/pept2prot.html.erb
@@ -235,7 +235,7 @@ ISVAQGASK	ref|NP_003881.2 XP_011547112.1 XP_011547113.1|	100	10	0	0	0	10	0	10	1e
             <li>Set format to blastTab and mode to blastp</li>
             <li>Remove the fasta mapping that was automatically added</li>
             <li>Enable the tabs you want (taxonomy/interpro2go/...), but always select the "use accession" option for this</li>
-            <li>Go back to the first tab and make sure is says blasttab and blastp, because sometimes it changes back when you switch tabs</li>
+            <li>Go back to the first tab and make sure it says blasttab and blastp, because sometimes it changes back when you switch tabs</li>
             <li>Click apply</li>
           </ul>
         </p>

--- a/app/views/api/clidocs/pept2prot.html.erb
+++ b/app/views/api/clidocs/pept2prot.html.erb
@@ -65,11 +65,11 @@ ISVAQGASK,A0A087WXI2,IgGFc-binding protein,9606</pre>
       <div class='card-supporting-text'>
         <p>
           The <code>unipept pept2prot</code> command outputs all UniProt entries that contain the given (tryptic) input peptides. By default, for each of the matching UniProt entries, the accession number, the name of the protein and the <span class='initialism'>NCBI</span> taxon id are returned. By using the <a href='#param-all'><samp>--all</samp> parameter</a>, this can be supplemented with the name of the associated taxon and several cross referenes such as the the associated EC numbers and GO terms. Consult the <a href='<%= api_apidocs_pept2prot_path %>#response' target='_blank'><span class="initialism">API</span> documentation</a> for a detailed list of output fields. A selection of output fields can be specified with the <a href='#param-select'><samp>--select</samp> parameter</a>. By default, output is generated in csv format. By using the <a href='#param-format'><samp>--format</samp> parameter</a>, the format can be changed into json or xml. The output can be written to a file or to <i>standard output</i>.
-    </p>
+        </p>
         <h4>File output</h4>
         <p>
           Use the <a href='#param-input'><samp>--output</samp> parameter</a> to specify an output file. If the file aready exists, the output will be appended to the end of the file.
-    </p>
+        </p>
         <pre>
 <b>$</b> unipept pept2prot --output output.txt MDGTEYIIVK ISVAQGASK
 <b>$</b> cat output.txt
@@ -80,7 +80,7 @@ ISVAQGASK,A0A087WXI2,IgGFc-binding protein,9606</pre>
         <h4>Standard output</h4>
         <p>
           If no output file is specified, <code>unipept pept2prot</code> will write its output to <i>standard output</i>.
-    </p>
+        </p>
         <h5>Example</h5>
         <pre>
 <b>$</b> unipept pept2prot MDGTEYIIVK ISVAQGASK
@@ -212,6 +212,33 @@ ISVAQGASK,A0A087WXI2,IgGFc-binding protein,Homo sapiens,</pre>
         <p>
           This flag displays the help.
     </p>
+      </div>
+    </div>
+    <div class='card'>
+      <div class='card-title card-title-colored'>
+        <h2 class='card-title-text' id='meganize'>Meganize</h2>
+      </div>
+      <div class='card-supporting-text'>
+        <p>
+          The <code>unipept pept2prot</code> command can be used in combination with Megan, for example to perform a functional analysis of the sample. This requires using the <code>--meganize</code> option that was added in version 1.2.0.
+        </p>
+        <h5>Example</h5>
+        <pre>
+<b>$</b> unipept pept2prot <b>--meganize</b> MDGTEYIIVK ISVAQGASK
+MDGTEYIIVK	ref|WP_008705701.1|	100	10	0	0	0	10	0	10	1e-100	100
+ISVAQGASK	ref|NP_003881.2 XP_011547112.1 XP_011547113.1|	100	10	0	0	0	10	0	10	1e-100	100</pre>
+        <p>
+          The generated output can be saved to a file and imported into Megan using the following settings:
+          <ul>
+            <li>Import from blast</li>
+            <li>Select the file with the <code>unipept pept2prot --meganize</code> output</li>
+            <li>Set format to blastTab and mode to blastp</li>
+            <li>Remove the fasta mapping that was automatically added</li>
+            <li>Enable the tabs you want (taxonomy/interpro2go/...), but always select the "use accession" option for this</li>
+            <li>Go back to the first tab and make sure is says blasttab and blastp, because sometimes it changes back when you switch tabs</li>
+            <li>Click apply</li>
+          </ul>
+        </p>
       </div>
     </div>
   </div>

--- a/app/views/api/shared/_sidebar.html.erb
+++ b/app/views/api/shared/_sidebar.html.erb
@@ -28,9 +28,7 @@
     $('.apidocs-sidebar').affix({
         offset: {
           top: $(".apidocs-sidebar").offset().top,
-          // bottom: 70 is needed to prevent overlap with the footer
-          // but it seems to be broken in bootstrap 3.3.1
-          //bottom: 70
+          bottom: 80
         }
     });
   });

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,7 +38,7 @@ module UnipeptWeb
 
     config.versions = {
       unipept: '3.2',
-      gem: '1.1.0',
+      gem: '1.3.0',
       uniprot: '2017.05'
     }
 


### PR DESCRIPTION
- bumps the minimal ruby version to 2.0
- bumps the recommended ruby version to 2.4
- bumps the gem version to 1.3.0
- add `--meganize` to the `unipept pept2prot` page

Closes #592


_[Original pull request](https://github.ugent.be/unipept/unipept/pull/617) by @bmesuere on Thu Aug 17 2017 at 14:25._
_Merged by @bmesuere on Thu Aug 17 2017 at 16:22._