### PR TITLE
Duplicate go_terms enteries that have alternative id's

### DIFF
--- a/backend/createGoTerms.sh.in
+++ b/backend/createGoTerms.sh.in
@@ -8,10 +8,19 @@ terms="http://geneontology.org/ontology/go-basic.obo"
 wget -q "$terms" -O - | <<<CMD_AWK>>> '
 BEGIN {
     OFS = "	"
+    id=1
 }
 /^\[.*\]$/ { # start of a record
     type = $0
+    alt_ctr = 0
     split("", record, ":")
+    split("", ids, ":")
+    next
+}
+/^(alt_id|id).*$/ { # a id or alt_id field in a record
+    value = $0; sub("[^ ]*: ", "", value)
+    record["id"][alt_ctr] = value
+    alt_ctr++
     next
 }
 !/^$/ { # a field in a record
@@ -20,10 +29,12 @@ BEGIN {
     record[key] = value
 }
 /^$/ { # end of a record
-    if (id != 0 && type == "[Term]") {
+    if (type == "[Term]") {
         sub("_", " ", record["namespace"])
-        print id, record["id"], record["namespace"], record["name"]
+        for(i in record["id"]){
+            print id, record["id"][i], record["namespace"], record["name"]
+            id++
+        }
     }
-    id++
     type = ""
 }'


### PR DESCRIPTION
I modified the script that gets GO terms so it duplicates entries that have multiple go-term numbers

---

In the obo file describing the GO terms, some entries had alternate IDs. These IDs were referenced in the `go_cross_refereces` which caused problems when agregating by namespace.

```
[Term]
id: GO:1990948
name: ubiquitin ligase inhibitor activity
namespace: molecular_function
alt_id: GO:0061637
alt_id: GO:0090645
...
```
With this edit the above `[Term]` is tranlated into 3 rows with identical go-term, name and namespace (but unique id)

This modification adds 2078 records to `go_terms`

---

In my opinion it would be better to either fix the referenced directly in the `go_cross_references` or to add an extra property to `go_term` that points to the original name. This would allow better aggregation of the GO-numbers.

_[Original pull request](https://github.ugent.be/unipept/unipept/pull/619) by @beardhatcode on Fri Oct 13 2017 at 15:13._
_Merged by @bmesuere on Wed Oct 25 2017 at 11:35._