### PR TITLE
From Yarn 1.0 onwards, scripts don't require "--" 

### DIFF
--- a/bin/webpack
+++ b/bin/webpack
@@ -21,7 +21,7 @@ unless File.exist?(WEBPACK_CONFIG)
 end
 
 newenv  = { "NODE_PATH" => NODE_MODULES_PATH.shellescape }
-cmdline = ["yarn", "run", "webpack", "--", "--config", WEBPACK_CONFIG] + ARGV
+cmdline = ["yarn", "run", "webpack", "--config", WEBPACK_CONFIG] + ARGV
 
 Dir.chdir(APP_PATH) do
   exec newenv, *cmdline

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -36,7 +36,7 @@ newenv = {
   "ASSET_HOST" => DEV_SERVER_HOST.shellescape
 }.freeze
 
-cmdline = ["yarn", "run", "webpack-dev-server", "--", "--progress", "--color", "--config", WEBPACK_CONFIG] + ARGV
+cmdline = ["yarn", "run", "webpack-dev-server", "--progress", "--color", "--config", WEBPACK_CONFIG] + ARGV
 
 Dir.chdir(APP_PATH) do
   exec newenv, *cmdline


### PR DESCRIPTION
Remove `--` that causes a warning

_[Original pull request](https://github.ugent.be/unipept/unipept/pull/631) by @beardhatcode on Thu Mar 22 2018 at 15:14._
_Merged by @bmesuere on Mon May 07 2018 at 17:02._