### PR TITLE
fix integer overflow for peptides

### DIFF
--- a/backend/src/main/java/org/unipept/storage/CSV.java
+++ b/backend/src/main/java/org/unipept/storage/CSV.java
@@ -61,7 +61,7 @@ public class CSV {
     }
 
     public static class IndexedWriter extends Writer {
-        private int index;
+        private long index;
         
         public IndexedWriter(String file) throws IOException {
             super(file);
@@ -70,14 +70,14 @@ public class CSV {
 
         @Override
         public void write(String... values) throws IOException {
-            buffer.write(Integer.toString(++index));
+            buffer.write(Long.toString(++index));
             for(int i = 0; i < values.length; i++) {
                 buffer.write("	" + (values[i] == null ? "\\N" : values[i]));
             }
             buffer.newLine();
         }
 
-        public int index() {
+        public long index() {
             return index;
         }
     }

--- a/backend/src/main/java/org/unipept/storage/TableWriter.java
+++ b/backend/src/main/java/org/unipept/storage/TableWriter.java
@@ -79,7 +79,7 @@ public class TableWriter implements UniprotObserver {
      *            the UniprotEntry to store
      */
     public void store(UniprotEntry entry) {
-        int uniprotEntryId = addUniprotEntry(entry.getUniprotAccessionNumber(), entry.getVersion(),
+        long uniprotEntryId = addUniprotEntry(entry.getUniprotAccessionNumber(), entry.getVersion(),
                 entry.getTaxonId(), entry.getType(), entry.getName(), entry.getSequence());
         if (uniprotEntryId != -1) { // failed to add entry
             for(String sequence : entry.digest()) {
@@ -113,7 +113,7 @@ public class TableWriter implements UniprotObserver {
      *            The full sequence of the peptide.
      * @return The database ID of the uniprot entry.
      */
-    public int addUniprotEntry(String uniprotAccessionNumber, int version, int taxonId,
+    public long addUniprotEntry(String uniprotAccessionNumber, int version, int taxonId,
             String type, String name, String sequence) {
         if(0 <= taxonId && taxonId < taxonList.size() && taxonList.get(taxonId) != null) {
             try {
@@ -179,12 +179,12 @@ public class TableWriter implements UniprotObserver {
      * @param originalSequence
      *            The original sequence of the peptide.
      */
-    public void addData(String unifiedSequence, int uniprotEntryId, String originalSequence) {
+    public void addData(String unifiedSequence, long uniprotEntryId, String originalSequence) {
         try {
             peptides.write(
                     unifiedSequence,
                     originalSequence,
-                    Integer.toString(uniprotEntryId)
+                    Long.toString(uniprotEntryId)
                     );
         } catch(IOException e) {
             System.err.println(new Timestamp(System.currentTimeMillis())
@@ -201,12 +201,12 @@ public class TableWriter implements UniprotObserver {
      * @param uniprotEntryId
      *            The uniprotEntry of the cross reference
      */
-    public void addDbRef(UniprotDbRef ref, int uniprotEntryId) {
+    public void addDbRef(UniprotDbRef ref, long uniprotEntryId) {
         try {
             CSV.Writer w = (ref.getType().equals("EMBL"))
                 ? emblCrossReferences
                 : refseqCrossReferences;
-            w.write(Integer.toString(uniprotEntryId),
+            w.write(Long.toString(uniprotEntryId),
                     ref.getProteinId(),
                     ref.getSequenceId());
         } catch (IOException e) {
@@ -224,9 +224,9 @@ public class TableWriter implements UniprotObserver {
      * @param uniprotEntryId
      *            The uniprotEntry of the cross reference
      */
-    public void addGORef(UniprotGORef ref, int uniprotEntryId) {
+    public void addGORef(UniprotGORef ref, long uniprotEntryId) {
         try {
-            goCrossReferences.write(Integer.toString(uniprotEntryId), ref.getId());
+            goCrossReferences.write(Long.toString(uniprotEntryId), ref.getId());
         } catch (IOException e) {
             System.err.println(new Timestamp(System.currentTimeMillis())
                     + " Error adding this GO reference to the database.");
@@ -243,9 +243,9 @@ public class TableWriter implements UniprotObserver {
      * @param uniprotEntryId
      *            The uniprotEntry of the cross reference
      */
-    public void addECRef(UniprotECRef ref, int uniprotEntryId) {
+    public void addECRef(UniprotECRef ref, long uniprotEntryId) {
         try {
-            ecCrossReferences.write(Integer.toString(uniprotEntryId), ref.getId());
+            ecCrossReferences.write(Long.toString(uniprotEntryId), ref.getId());
         } catch (IOException e) {
             System.err.println(new Timestamp(System.currentTimeMillis())
                     + " Error adding this EC reference to the database.");
@@ -262,9 +262,9 @@ public class TableWriter implements UniprotObserver {
      * @param uniprotEntryId
      *            The uniprotEntry of the cross reference
      */
-    public void addProteomeRef(UniprotProteomeRef ref, int uniprotEntryId) {
+    public void addProteomeRef(UniprotProteomeRef ref, long uniprotEntryId) {
         try {
-            proteomeCrossReferences.write(Integer.toString(uniprotEntryId), Integer.toString(getProteomeId(ref.getId())));
+            proteomeCrossReferences.write(Long.toString(uniprotEntryId), Integer.toString(getProteomeId(ref.getId())));
         } catch (IOException e) {
             System.err.println(new Timestamp(System.currentTimeMillis())
                     + " Error adding this Proteome reference to the database.");


### PR DESCRIPTION
Change the `IndexedWriter` to use a long as index rather than an int.+

In the database, the indexes are stored as `int(10)`, which is enough for now.

```bash
$ zcat tables/peptides.tsv.gz | wc -l
2353109178
```

An alternative to this solution is to use [`toUnsignedString(int i, int radix)`](https://docs.oracle.com/javase/8/docs/api/java/lang/Integer.html#toUnsignedString-int-int-)

_[Original pull request](https://github.ugent.be/unipept/unipept/pull/633) by @beardhatcode on Fri Apr 06 2018 at 13:24._
_Merged by @bmesuere on Mon May 07 2018 at 16:59._