### PR TITLE
Only send Unipept as referer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <link rel="icon" sizes="192x192" href="/logo.png">
     <link rel="apple-touch-icon-precomposed" href="/logo.png" />
     <link rel="shortcut icon" href="/favicon.ico" />
+    <meta name="referrer" content="origin">
     <% if Rails.application.config.unipept_analytics %>
       <!-- Google Analytics -->
       <script type="text/javascript">


### PR DESCRIPTION
This makes shure only the 
```
Refferer: https://unipept.ugent.be
```
is sent instead of the full url (http://localhost:5000/sequences/AALER/equateIL)
```
Refferer: https://unipept.ugent.be/sequences/AALER/equateIL
```

The additional benefit is that it does not break other sites if the Refferer is too long, which was the case for with QuickGO

_[Original pull request](https://github.ugent.be/unipept/unipept/pull/640) by @beardhatcode on Thu Jun 14 2018 at 14:14._
_Merged by @bmesuere on Thu Jun 14 2018 at 14:44._