### PR TITLE
add timestamp to makefile steps

### DIFF
--- a/backend/configure
+++ b/backend/configure
@@ -154,6 +154,10 @@ echo "s|<<<ENTREZ_URL>>>|$ENTREZ_URL|g" >> "$sedscript"
 TAXON_URL="http://ftp.ncbi.nih.gov/pub/taxonomy/taxdmp.zip"
 echo "s|<<<TAXON_URL>>>|$TAXON_URL|g" >> "$sedscript"
 
+LOGADD='echo $$(date +"[%s (%F %T)]")'
+echo "s|^\t<<<LOGADD>>>|\t@$LOGADD|" >> "$sedscript"
+echo "s|<<<LOGADD>>>|echo|g" >> "$sedscript"
+
 # --------------------------------------------------------------------
 # Writing the configured files
 
@@ -189,11 +193,11 @@ for (( i = 0 ; i < sources_count ; i += 2 )); do
     url="${CONFIG_SOURCES[$((i + 1))]}"
     cat >> "$tmpmakefile" <<HERE
 $file:
-	echo "Starting downloading $name."
+	$LOGADD "Started downloading $name."
 	mkdir -p $CONFIG_SRCDIR
 	rm -f $file
 	wget --progress=dot:giga "$url" -O $file
-	echo "Finished downloading $name."
+	$LOGADD "Finished downloading $name."
 
 HERE
 done

--- a/backend/makefile.in
+++ b/backend/makefile.in
@@ -53,31 +53,31 @@ $(JAR): $(SRC)
 
 # Taxons and Lineages {{{ ------------------------------------------------------
 <<<TAXDIR>>>/taxdmp.zip:
-	echo "Starting taxon dump download."
+	<<<LOGADD>>> "Started taxon dump download."
 	mkdir -p <<<TAXDIR>>>
 	-rm -f $@
 	wget --no-verbose "<<<TAXON_URL>>>" -O $@
-	echo "Finished taxon dump download."
+	<<<LOGADD>>> "Finished taxon dump download."
 
 <<<INTDIR>>>/names.dmp <<<INTDIR>>>/nodes.dmp: <<<TAXDIR>>>/taxdmp.zip
-	echo "Starting unzipping names and nodes from the taxon dump."
+	<<<LOGADD>>> "Started unzipping names and nodes from the taxon dump."
 	<<<CMD_UNZIP>>> -o $< $(notdir $@) -d $(dir $@)
-	echo "Finished unzipping names and nodes from the taxon dump."
+	<<<LOGADD>>> "Finished unzipping names and nodes from the taxon dump."
 
 <<<TABDIR>>>/taxons.tsv.gz <<<TABDIR>>>/lineages.tsv.gz: $(JAR) <<<INTDIR>>>/names.dmp <<<INTDIR>>>/nodes.dmp
-	echo "Starting calculation of taxons and lineages tables."
+	<<<LOGADD>>> "Started calculation of taxons and lineages tables."
 	mkdir -p $(dir $@)
 	java -Xms<<<JAVA_MEM>>> -Xmx<<<JAVA_MEM>>> -cp $(JAR) $(PAC).NamesNodes2TaxonsLineages \
 		--names <<<INTDIR>>>/names.dmp \
 		--nodes <(<<<CMD_SED>>> 's/cohort/no rank/' <<<INTDIR>>>/nodes.dmp) \
 		--taxons >(<<<CMD_GZIP>>> > <<<TABDIR>>>/taxons.tsv.gz) \
 		--lineages >(<<<CMD_GZIP>>> > <<<TABDIR>>>/lineages.tsv.gz)
-	echo "Finished calculation of taxons and lineages tables."
+	<<<LOGADD>>> "Finished calculation of taxons and lineages tables."
 # }}}
 
 # Uniprot entries, peptides, sequences and cross references {{{ ----------------
 $(TABLES): $(JAR) <<<TABDIR>>>/taxons.tsv.gz <<<SOURCE_FILES>>>
-	echo "Started calculation of most tables."
+	<<<LOGADD>>> "Started calculation of most tables."
 	mkdir -p <<<INTDIR>>>
 	java -Xms<<<JAVA_MEM>>> -Xmx<<<JAVA_MEM>>> -cp $(JAR) $(PAC).TaxonsUniprots2Tables \
 		--peptide-min     <<<PEPTIDE_MIN_LENGTH>>> \
@@ -92,12 +92,12 @@ $(TABLES): $(JAR) <<<TABDIR>>>/taxons.tsv.gz <<<SOURCE_FILES>>>
 		--proteomes       >(<<<CMD_GZIP>>> > <<<INTDIR>>>/proteomes.tsv.gz) \
 		--proteomes-ref   >(<<<CMD_GZIP>>> > <<<TABDIR>>>/proteome_cross_references.tsv.gz) \
 		<<<SOURCE_INPUTS>>>
-	echo "Finished calculation of most tables."
+	<<<LOGADD>>> "Finished calculation of most tables."
 # }}}
 
 # Sequences with LCA {{{ -------------------------------------------------------
 <<<INTDIR>>>/aa_sequence_taxon.tsv.gz: <<<INTDIR>>>/peptides.tsv.gz <<<TABDIR>>>/uniprot_entries.tsv.gz
-	echo "Starting the joining of equalized peptides and uniprot entries."
+	<<<LOGADD>>> "Started the joining of equalized peptides and uniprot entries."
 	mkdir -p <<<INTDIR>>>
 	<<<CMD_JOIN>>> -t '	' -o '1.2,2.2' -j 1 \
 			<(<<<CMD_ZCAT>>> <<<INTDIR>>>/peptides.tsv.gz | <<<CMD_AWK>>> '{ printf("%012d\t%s\n", $$4, $$2) }') \
@@ -105,10 +105,10 @@ $(TABLES): $(JAR) <<<TABDIR>>>/taxons.tsv.gz <<<SOURCE_FILES>>>
 		| LC_ALL=C <<<CMD_SORT>>> -k1 \
 		| <<<CMD_GZIP>>> \
 		> $@
-	echo "Finished the joining of equalized peptides and uniprot entries."
+	<<<LOGADD>>> "Finished the joining of equalized peptides and uniprot entries."
 
 <<<INTDIR>>>/original_aa_sequence_taxon.tsv.gz: <<<INTDIR>>>/peptides.tsv.gz <<<TABDIR>>>/uniprot_entries.tsv.gz
-	echo "Starting the joining of non-equalized peptides and uniprot entries."
+	<<<LOGADD>>> "Started the joining of non-equalized peptides and uniprot entries."
 	mkdir -p <<<INTDIR>>>
 	<<<CMD_JOIN>>> -t '	' -o '1.2,2.2' -j 1 \
 			<(<<<CMD_ZCAT>>> <<<INTDIR>>>/peptides.tsv.gz | <<<CMD_AWK>>> '{ printf("%012d\t%s\n", $$4, $$3) }') \
@@ -116,10 +116,10 @@ $(TABLES): $(JAR) <<<TABDIR>>>/taxons.tsv.gz <<<SOURCE_FILES>>>
 		| LC_ALL=C <<<CMD_SORT>>> -k1 \
 		| <<<CMD_GZIP>>> \
 		> $@
-	echo "Finished the joining of non-equalized peptides and uniprot entries."
+	<<<LOGADD>>> "Finished the joining of non-equalized peptides and uniprot entries."
 
 <<<INTDIR>>>/sequences.tsv.gz: <<<INTDIR>>>/aa_sequence_taxon.tsv.gz <<<INTDIR>>>/original_aa_sequence_taxon.tsv.gz
-	echo "Starting the numbering of sequences."
+	<<<LOGADD>>> "Started the numbering of sequences."
 	LC_ALL=C <<<CMD_SORT>>> -m \
 			<(<<<CMD_ZCAT>>> <<<INTDIR>>>/aa_sequence_taxon.tsv.gz | cut -f1) \
 			<(<<<CMD_ZCAT>>> <<<INTDIR>>>/original_aa_sequence_taxon.tsv.gz | cut -f1) \
@@ -128,10 +128,10 @@ $(TABLES): $(JAR) <<<TABDIR>>>/taxons.tsv.gz <<<SOURCE_FILES>>>
 		| <<<CMD_SED>>> 's/^ *//' \
 		| <<<CMD_GZIP>>> \
 		> $@
-	echo "Finishing the numbering of sequences."
+	<<<LOGADD>>> "Finished the numbering of sequences."
 
 <<<TABDIR>>>/peptides.tsv.gz: <<<INTDIR>>>/peptides.tsv.gz <<<INTDIR>>>/sequences.tsv.gz
-	echo "Starting the substitution of AA's by ID's for the peptides."
+	<<<LOGADD>>> "Started the substitution of AA's by ID's for the peptides."
 	<<<CMD_ZCAT>>> <<<INTDIR>>>/peptides.tsv.gz \
 		| LC_ALL=C <<<CMD_SORT>>> -k 2b,2 \
 		| <<<CMD_JOIN>>> -t '	' -o '1.1,2.1,1.3,1.4' -1 2 -2 2 - <(<<<CMD_ZCAT>>> <<<INTDIR>>>/sequences.tsv.gz) \
@@ -140,59 +140,59 @@ $(TABLES): $(JAR) <<<TABDIR>>>/taxons.tsv.gz <<<SOURCE_FILES>>>
 		| LC_ALL=C <<<CMD_SORT>>> -n \
 		| <<<CMD_GZIP>>> \
 		> $@
-	echo "Finishing the substitution of AA's by ID's for the peptides."
+	<<<LOGADD>>> "Finished the substitution of AA's by ID's for the peptides."
 
 <<<INTDIR>>>/sequence_taxon.tsv.gz: <<<INTDIR>>>/sequences.tsv.gz <<<INTDIR>>>/aa_sequence_taxon.tsv.gz
-	echo "Starting the substitution of AA's by ID's for the sequences"
+	<<<LOGADD>>> "Started the substitution of AA's by ID's for the sequences"
 	<<<CMD_JOIN>>> -t '	' -o '1.1,2.2' -1 2 -2 1 \
 			<(<<<CMD_ZCAT>>> <<<INTDIR>>>/sequences.tsv.gz) \
 			<(<<<CMD_ZCAT>>> <<<INTDIR>>>/aa_sequence_taxon.tsv.gz) \
 		| <<<CMD_GZIP>>> \
 		> $@
-	echo "Finishing the substitution of AA's by ID's for the sequences"
+	<<<LOGADD>>> "Finished the substitution of AA's by ID's for the sequences"
 
 <<<INTDIR>>>/original_sequence_taxon.tsv.gz: <<<INTDIR>>>/sequences.tsv.gz <<<INTDIR>>>/original_aa_sequence_taxon.tsv.gz
-	echo "Starting the substitution of AA's by ID's for the original sequences"
+	<<<LOGADD>>> "Started the substitution of AA's by ID's for the original sequences"
 	<<<CMD_JOIN>>> -t '	' -o '1.1,2.2' -1 2 -2 1 \
 			<(<<<CMD_ZCAT>>> <<<INTDIR>>>/sequences.tsv.gz) \
 			<(<<<CMD_ZCAT>>> <<<INTDIR>>>/original_aa_sequence_taxon.tsv.gz) \
 		| <<<CMD_GZIP>>> \
 		> $@
-	echo "Finishing the substitution of AA's by ID's for the original sequences"
+	<<<LOGADD>>> "Finished the substitution of AA's by ID's for the original sequences"
 
 <<<INTDIR>>>/LCAs.tsv.gz: <<<TABDIR>>>/lineages.tsv.gz <<<INTDIR>>>/sequence_taxon.tsv.gz
-	echo "Starting the calculation of equalized LCA's."
+	<<<LOGADD>>> "Started the calculation of equalized LCA's."
 	java -Xms<<<JAVA_MEM>>> -Xmx<<<JAVA_MEM>>> -cp $(JAR) $(PAC).LineagesSequencesTaxons2LCAs \
 		<(<<<CMD_ZCAT>>> <<<TABDIR>>>/lineages.tsv.gz) \
 		<(<<<CMD_ZCAT>>> <<<INTDIR>>>/sequence_taxon.tsv.gz) \
 		>(<<<CMD_GZIP>>> > <<<INTDIR>>>/LCAs.tsv.gz)
-	echo "Finished the calculation of equalized LCA's."
+	<<<LOGADD>>> "Finished the calculation of equalized LCA's."
 
 <<<INTDIR>>>/original_LCAs.tsv.gz: <<<TABDIR>>>/lineages.tsv.gz <<<INTDIR>>>/original_sequence_taxon.tsv.gz
-	echo "Starting the calculation of non-equalized LCA's."
+	<<<LOGADD>>> "Started the calculation of non-equalized LCA's."
 	java -Xms<<<JAVA_MEM>>> -Xmx<<<JAVA_MEM>>> -cp $(JAR) $(PAC).LineagesSequencesTaxons2LCAs \
 		<(<<<CMD_ZCAT>>> <<<TABDIR>>>/lineages.tsv.gz) \
 		<(<<<CMD_ZCAT>>> <<<INTDIR>>>/original_sequence_taxon.tsv.gz) \
 		>(<<<CMD_GZIP>>> > <<<INTDIR>>>/original_LCAs.tsv.gz)
-	echo "Finished the calculation of non-equalized LCA's."
+	<<<LOGADD>>> "Finished the calculation of non-equalized LCA's."
 
 <<<INTDIR>>>/FAs.tsv.gz: <<<INTDIR>>>/peptides.tsv.gz
-	echo "Starting the calculation of equalized FA's."
+	<<<LOGADD>>> "Started the calculation of equalized FA's."
 	java -Xms<<<JAVA_MEM>>> -Xmx<<<JAVA_MEM>>> -cp $(JAR) $(PAC).FunctionAnalysisPeptides \
 		<(<<<CMD_ZCAT>>> <<<INTDIR>>>/peptides.tsv.gz | cut -f2,5 | LC_ALL=C <<<CMD_SORT>>> -k 1b,1) \
 		>(<<<CMD_GZIP>>> - > <<<INTDIR>>>/FAs.tsv.gz)
-	echo "Finished the calculation of equalized FA's."
+	<<<LOGADD>>> "Finished the calculation of equalized FA's."
 	
 <<<INTDIR>>>/original_FAs.tsv.gz: <<<INTDIR>>>/peptides.tsv.gz
-	echo "Starting the calculation of non-equalized FA's."
+	<<<LOGADD>>> "Started the calculation of non-equalized FA's."
 	java -Xms<<<JAVA_MEM>>> -Xmx<<<JAVA_MEM>>> -cp $(JAR) $(PAC).FunctionAnalysisPeptides \
 		<(<<<CMD_ZCAT>>> <<<INTDIR>>>/peptides.tsv.gz | cut -f3,5 | LC_ALL=C <<<CMD_SORT>>> -k 1b,1) \
 		>(<<<CMD_GZIP>>> - > <<<INTDIR>>>/original_FAs.tsv.gz)
-	echo "Finished the calculation of non-equalized FA's."
+	<<<LOGADD>>> "Finished the calculation of non-equalized FA's."
 
 
 <<<TABDIR>>>/sequences.tsv.gz: <<<INTDIR>>>/sequences.tsv.gz <<<INTDIR>>>/LCAs.tsv.gz <<<INTDIR>>>/original_LCAs.tsv.gz <<<INTDIR>>>/original_FAs.tsv.gz <<<INTDIR>>>/FAs.tsv.gz
-	echo "Starting the creation of the sequences table."
+	<<<LOGADD>>> "Started the creation of the sequences table."
 	<<<CMD_ZCAT>>> <<<INTDIR>>>/sequences.tsv.gz \
 		| <<<CMD_AWK>>> '{ printf("%012d\t%s\n", $$1, $$2) }' \
 		| <<<CMD_JOIN>>> --nocheck-order -a1 -e '\N' -t '	' -o "1.1 1.2 2.2"                       - <(<<<CMD_ZCAT>>> <<<INTDIR>>>/original_LCAs.tsv.gz | <<<CMD_AWK>>> '{ printf("%012d\t%s\n", $$1, $$2) }') \
@@ -202,7 +202,7 @@ $(TABLES): $(JAR) <<<TABDIR>>>/taxons.tsv.gz <<<SOURCE_FILES>>>
 		| <<<CMD_SED>>> 's/^0*//' \
 		| <<<CMD_GZIP>>> \
 		> $@
-	echo "Finished the creation of the sequences table."
+	<<<LOGADD>>> "Finished the creation of the sequences table."
 # }}}
 
 # K-mers {{{ -------------------------------------------------------------------
@@ -227,46 +227,46 @@ $(TABLES): $(JAR) <<<TABDIR>>>/taxons.tsv.gz <<<SOURCE_FILES>>>
 # | build-index
 
 <<<INTDIR>>>/<<<KMER_LENGTH>>>-mer_sequence_taxon.tsv.gz: <<<TABDIR>>>/uniprot_entries.tsv.gz
-	echo "Starting the enumeration of <<<KMER_LENGTH>>>-mers."
+	<<<LOGADD>>> "Started the enumeration of <<<KMER_LENGTH>>>-mers."
 	<<<CMD_ZCAT>>> <<<TABDIR>>>/uniprot_entries.tsv.gz \
 		| cut -f4,7 \
 		| <<<CMD_AWK>>> -v OFS='	' '{ for(i = length($$2) - <<<KMER_LENGTH>>> + 1; i > 0; i -= 1) print(substr($$2, i, <<<KMER_LENGTH>>>), $$1) }' \
 		| <<<CMD_SORT>>> \
 		| <<<CMD_GZIP>>> \
 		> $@
-	echo "Finishing the enumeration of <<<KMER_LENGTH>>>-mers."
+	<<<LOGADD>>> "Finished the enumeration of <<<KMER_LENGTH>>>-mers."
 
 <<<INTDIR>>>/<<<KMER_LENGTH>>>-mer_LCAs.tsv.gz: <<<INTDIR>>>/<<<KMER_LENGTH>>>-mer_sequence_taxon.tsv.gz <<<TABDIR>>>/lineages.tsv.gz
-	echo "Starting the calculation of <<<KMER_LENGTH>>>-mer LCA's."
+	<<<LOGADD>>> "Started the calculation of <<<KMER_LENGTH>>>-mer LCA's."
 	java -Xms<<<JAVA_MEM>>> -Xmx<<<JAVA_MEM>>> -cp $(JAR) $(PAC).LineagesSequencesTaxons2LCAs \
 		<(<<<CMD_ZCAT>>> <<<TABDIR>>>/lineages.tsv.gz) \
 		<(<<<CMD_ZCAT>>> <<<INTDIR>>>/<<<KMER_LENGTH>>>-mer_sequence_taxon.tsv.gz) \
 		>(<<<CMD_GZIP>>> > $@)
-	echo "Finished the calculation of <<<KMER_LENGTH>>>-mer LCA's."
+	<<<LOGADD>>> "Finished the calculation of <<<KMER_LENGTH>>>-mer LCA's."
 
 <<<TABDIR>>>/<<<KMER_LENGTH>>>-mer.index: <<<INTDIR>>>/<<<KMER_LENGTH>>>-mer_LCAs.tsv.gz
-	echo "Starting the construction of the <<<KMER_LENGTH>>>-mer index."
+	<<<LOGADD>>> "Started the construction of the <<<KMER_LENGTH>>>-mer index."
 	build-index <(<<<CMD_ZCAT>>> $<) $@
-	echo "Finishing the construction of the <<<KMER_LENGTH>>>-mer index."
+	<<<LOGADD>>> "Finished the construction of the <<<KMER_LENGTH>>>-mer index."
 # }}}
 
 # Proteomes {{{ ----------------------------------------------------------------
 
 <<<INTDIR>>>/proteomes_data.tsv.gz: $(JAR) <<<INTDIR>>>/proteomes.tsv.gz
-	echo "Starting fetching of proteome data."
+	<<<LOGADD>>> "Started fetching of proteome data."
 	java -Xms<<<JAVA_MEM>>> -Xmx<<<JAVA_MEM>>> -cp $(JAR) $(PAC).FetchProteomes \
 		<(<<<CMD_ZCAT>>> <<<INTDIR>>>/proteomes.tsv.gz) \
 		>(<<<CMD_SORT>>> -t $$'\t' -k 6 | <<<CMD_GZIP>>> > $@) # sort by assembly
-	echo "Finished fetching of proteome data."
+	<<<LOGADD>>> "Finished fetching of proteome data."
 
 <<<INTDIR>>>/proteomes_type_strains.tsv.gz: type_strains.sh
-	echo "Starting fetching of type strain data."
+	<<<LOGADD>>> "Started fetching of type strain data."
 	./type_strains.sh | <<<CMD_SED>>> 's/$$/\t1/' | <<<CMD_GZIP>>> > $@
-	echo "Finished fetching of type strain data."
+	<<<LOGADD>>> "Finished fetching of type strain data."
 
 
 <<<TABDIR>>>/proteomes.tsv.gz: <<<INTDIR>>>/proteomes_data.tsv.gz <<<INTDIR>>>/proteomes_type_strains.tsv.gz 
-	echo "Starting adding type strain boolean to proteome data."
+	<<<LOGADD>>> "Started adding type strain boolean to proteome data."
 	# tmp: 1)id 2)accession-id 3)name-str 4)reference-bool 5)strain-id 6)assembly-id
 	# strain: assembly-id
 
@@ -280,19 +280,19 @@ $(TABLES): $(JAR) <<<TABDIR>>>/taxons.tsv.gz <<<SOURCE_FILES>>>
 		| <<<CMD_SORT>>> -n \
 		| <<<CMD_GZIP>>> \
 		> $@
-	echo "Finished adding type strain boolean to proteome data."
+	<<<LOGADD>>> "Finished adding type strain boolean to proteome data."
 # }}}
 
 # Functional Data {{{ ----------------------------------------------------------
 <<<TABDIR>>>/ec_numbers.tsv.gz: createEcNumbers.sh
-	echo "Starting creating EC numbers"
+	<<<LOGADD>>> "Started creating EC numbers"
 	./createEcNumbers.sh | <<<CMD_GZIP>>> > $@
-	echo "Finished creating EC numbers."
+	<<<LOGADD>>> "Finished creating EC numbers."
 
 <<<TABDIR>>>/go_terms.tsv.gz: createGoTerms.sh
-	echo "Starting creating GO terms"
+	<<<LOGADD>>> "Started creating GO terms"
 	./createGoTerms.sh | <<<CMD_GZIP>>> > $@
-	echo "Finished creating GO terms."
+	<<<LOGADD>>> "Finished creating GO terms."
 # }}}
 
 .PHONY: clean_intermediates


### PR DESCRIPTION
The output of make will now show lines like

    [1550673307 (2019-02-20 15:35:07)] Starting calculation of taxons and lineages tables.

This will allow calculating the duration of each step.

_[Original pull request](https://github.ugent.be/unipept/unipept/pull/664) by @beardhatcode on Wed Feb 20 2019 at 15:53._