### PR TITLE
Update the config to run on the HPC

### DIFF
--- a/backend/latest-config-hpc-phanpy
+++ b/backend/latest-config-hpc-phanpy
@@ -3,10 +3,10 @@
 # Editting this file does not configure the unipept backend run, it will
 # only change the suggested configuration when you run `./configure`.
 CONFIG_KMER_LENGTH="9"
-CONFIG_TABDIR="/user/data/gent/gvo000/gvo00038/vsc41079/data/tables"
-CONFIG_INTDIR="/user/data/gent/gvo000/gvo00038/vsc41079/data/intermediate"
-CONFIG_TAXDIR="/user/data/gent/gvo000/gvo00038/vsc41079/data/sources"
-CONFIG_SRCDIR="/user/data/gent/gvo000/gvo00038/vsc41079/data/sources"
+CONFIG_TABDIR="/data/gent/vo/000/gvo00038/vsc41079/data/tables"
+CONFIG_INTDIR="/data/gent/vo/000/gvo00038/vsc41079/data/intermediate"
+CONFIG_TAXDIR="/data/gent/vo/000/gvo00038/vsc41079/data/sources"
+CONFIG_SRCDIR="/data/gent/vo/000/gvo00038/vsc41079/data/sources"
 CONFIG_JAVA_MEM="8g"
 CONFIG_ENTREZ_BATCH_SIZE="1000"
 CONFIG_CMD_SORT="sort --parallel=24"

--- a/backend/make-on-hpc.sh
+++ b/backend/make-on-hpc.sh
@@ -1,10 +1,8 @@
 #!/bin/sh
 #PBS -N unipept-backend
-#PBS -q long
-#PBS -m abe
 #PBS -l nodes=1:ppn=24
 #PBS -l walltime=72:00:00
-#PBS -l vmem=500gb
+#PBS -l vmem=480gb
 
 # Running:
 # $ module swap cluster/phanpy


### PR DESCRIPTION
The HPC has reinstalled Slurm and phanpy lost some memory in the
processes. The queues have also been renamed. There is no longer a
"long" queue.

Also: The paths have changed. there are symlinks at the moment but it is better to update them now.

See #665

_[Original pull request](https://github.ugent.be/unipept/unipept/pull/668) by @beardhatcode on Wed Mar 27 2019 at 11:36._
_Merged by @ninewise on Thu Mar 28 2019 at 13:22._