### PR TITLE
Get rid of double D3-inclusion for some applications

### DIFF
--- a/app/views/datasets/index.html.erb
+++ b/app/views/datasets/index.html.erb
@@ -1,5 +1,4 @@
 <% content_for :javascripts do %>
-  <%= javascript_pack_tag 'd3' %>
   <%= javascript_pack_tag 'mpa_app' %>
 <% end %>
 

--- a/app/views/mpa/analyze.html.erb
+++ b/app/views/mpa/analyze.html.erb
@@ -1,5 +1,4 @@
 <% content_for :javascripts do %>
-  <%= javascript_pack_tag 'd3' %>
   <%= javascript_pack_tag 'mpa_app' %>
 <% end %>
 

--- a/app/views/peptidome/analyze.html.erb
+++ b/app/views/peptidome/analyze.html.erb
@@ -1,5 +1,4 @@
 <% content_for :javascripts do %>
-  <%= javascript_pack_tag 'd3' %>
   <%= javascript_pack_tag 'pancore' %>
 <% end %>
 

--- a/app/views/sequences/show.html.erb
+++ b/app/views/sequences/show.html.erb
@@ -1,5 +1,4 @@
 <% content_for :javascripts do %>
-  <%= javascript_pack_tag 'd3' %>
   <%= javascript_pack_tag 'sequence_show' %>
 <% end %>
 <h1><%= @title %></h1>


### PR DESCRIPTION
D3 was included once through a script-tag and once through the d3_pack in some applications. This PR fixes the double inclusion.