### PR TITLE
Fixed crash due to some interpro entries being nil

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,8 @@ Metrics/PerceivedComplexity:
   Enabled: false
 Metrics/CyclomaticComplexity:
   Enabled: false
+Metrics/BlockNesting:
+  Enabled: false
 Naming/AccessorMethodName:
   Enabled: false
 Naming/PredicateName:

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -445,8 +445,11 @@ class Api::ApiController < ApplicationController
 
           v[:ipr].each do |value|
             ipr_entry = ipr_mapping[value[:code]]
-            value[:name] = ipr_entry.name if @extra_info
-            splitted[ipr_entry.category] << value
+
+            if !ipr_entry.nil?
+              value[:name] = ipr_entry.name if @extra_info
+              splitted[ipr_entry.category] << value
+            end
           end
 
           v[:ipr] = splitted
@@ -456,8 +459,10 @@ class Api::ApiController < ApplicationController
           v[:ipr].each do |value|
             ipr_entry = ipr_mapping[value[:code]]
 
-            value[:name] = ipr_entry.name
-            value[:type] = ipr_entry.category
+            if !ipr_entry.nil?
+              value[:name] = ipr_entry.name
+              value[:type] = ipr_entry.category
+            end
           end
         end
       end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -446,7 +446,7 @@ class Api::ApiController < ApplicationController
           v[:ipr].each do |value|
             ipr_entry = ipr_mapping[value[:code]]
 
-            if !ipr_entry.nil?
+            unless ipr_entry.nil?
               value[:name] = ipr_entry.name if @extra_info
               splitted[ipr_entry.category] << value
             end
@@ -458,8 +458,8 @@ class Api::ApiController < ApplicationController
         output.map do |_k, v|
           v[:ipr].each do |value|
             ipr_entry = ipr_mapping[value[:code]]
-            value[:name] = "" if ipr_entry.nil? else ipr_entry.name 
-            value[:type] = "" if ipr_entry.nil? else ipr_entry.category
+            value[:name] = ipr_entry.nil? ? '' : ipr_entry.name
+            value[:type] = ipr_entry.nil? ? '' : ipr_entry.category
           end
         end
       end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -458,11 +458,8 @@ class Api::ApiController < ApplicationController
         output.map do |_k, v|
           v[:ipr].each do |value|
             ipr_entry = ipr_mapping[value[:code]]
-
-            if !ipr_entry.nil?
-              value[:name] = ipr_entry.name
-              value[:type] = ipr_entry.category
-            end
+            value[:name] = "" if ipr_entry.nil? else ipr_entry.name 
+            value[:type] = "" if ipr_entry.nil? else ipr_entry.category
           end
         end
       end


### PR DESCRIPTION
Some proteins are annotated with an InterPro-code that no longer exists and which is not present in the `interpro_entries`-table. This entry is then `nil` in `api_controller` and causes the application to crash.

An extra check is added to make sure that entries are valid before we are trying to use them.