### PR TITLE
Fix "cannot read property join of undefined"

### DIFF
--- a/app/assets/javascripts/mpa/components/App.vue
+++ b/app/assets/javascripts/mpa/components/App.vue
@@ -4,7 +4,7 @@
             v-if="!isAnalysis"
             v-on:start-analysis="onStartAnalysis">
         </home-page>
-        <analysis-page v-else :project="project"></analysis-page>
+        <analysis-page v-else></analysis-page>
     </v-app>
 </template>
 

--- a/app/assets/javascripts/mpa/components/dataset/LoadDatasetsCard.vue
+++ b/app/assets/javascripts/mpa/components/dataset/LoadDatasetsCard.vue
@@ -76,6 +76,7 @@ import ProteomicsAssay from "unipept-web-components/src/business/entities/assay/
 import Tooltip from "unipept-web-components/src/custom/Tooltip.vue";
 import BrowserStorageRemover from "unipept-web-components/src/business/storage/browser/assay/BrowserStorageRemover";
 import BrowserStorageWriter from "unipept-web-components/src/business/storage/browser/assay/BrowserStorageWriter";
+import BrowserStorageDataReader from "unipept-web-components/src/business/storage/browser/assay/BrowserStorageDataReader";
 
 @Component({
     components: {
@@ -98,8 +99,12 @@ export default class LoadDatasetsCard extends Vue {
     private currentTab: number = 0;
     private errorSnackbar: boolean = false;
 
-    private onCreateAssay(assay: ProteomicsAssay) {
-        this.$store.dispatch("addAssay", assay);
+    private async onCreateAssay(assay: ProteomicsAssay) {
+        if (!assay.getPeptides()) {
+            const browserStorageDataReader = new BrowserStorageDataReader(window.localStorage);
+            await assay.accept(browserStorageDataReader);
+        }
+        await this.$store.dispatch("addAssay", assay);
         this.$emit("create-assay", assay);
     }
 


### PR DESCRIPTION
This PR fixes a bug where the error "cannot read property join of undefined" occurs if the user tries to process a sample from local storage.