### PR TITLE
API monitoring action

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -3,7 +3,7 @@ name: Uptime
 on: [push]
 
 jobs:
-  test:
+  uptime:
     runs-on: ubuntu-latest
     container:
       image: ruby:2.6.5

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -11,8 +11,13 @@ jobs:
       - name: Install Unipept Gem
         run: |
           gem install unipept
+      - name: Install required utilities
+        run: |
+          apt-get update
+          apt-get -y install bc
       - uses: actions/checkout@v2
       - name: Run uptime check
+        shell: bash
         run: |
           chmod u+x ./test/uptime/check_uptime_api.sh
           ./test/uptime/check_uptime_api.sh

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   uptime:
     runs-on: ubuntu-latest
-    container:
-      image: ruby:2.6.5
     steps:
       - name: Install required utilities
         run: |

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Run uptime check
         run: |
           chmod u+x ./test/uptime/check_uptime_api.sh
-          ./check_uptime_api.sh
+          ./test/uptime/check_uptime_api.sh

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,18 @@
+name: Uptime
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ruby:2.6.5
+    steps:
+      - name: Install Unipept Gem
+        run: |
+          gem install unipept
+      - uses: actions/checkout@v2
+      - name: Run uptime check
+        run: |
+          chmod u+x ./test/uptime/check_uptime_api.sh
+          ./check_uptime_api.sh

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,6 +1,9 @@
 name: Uptime
 
-on: [push]
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 * * * *'
 
 jobs:
   uptime:
@@ -8,9 +11,6 @@ jobs:
     container:
       image: ruby:2.6.5
     steps:
-      - name: Install Unipept Gem
-        run: |
-          gem install unipept
       - name: Install required utilities
         run: |
           apt-get update

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -232,6 +232,11 @@ class Api::ApiController < ApplicationController
       )
 
       @gist = result[:html_url]
+
+      if @remove
+        # Immediately delete the gist again. This is used for testing the uptime of the API server
+        client.delete_gist(result[:id])
+      end
     end
 
     render layout: false
@@ -291,6 +296,7 @@ class Api::ApiController < ApplicationController
     @names = params[:names] == 'true'
     @domains = params[:domains] == 'true'
     @extra_info = params[:extra] == 'true'
+    @remove = params[:remove] == 'true'
 
     @input = @input.map { |s| s.tr('I', 'L') } if @equate_il
   end

--- a/test/uptime/check_uptime_api.sh
+++ b/test/uptime/check_uptime_api.sh
@@ -1,0 +1,25 @@
+# This script checks if the API-server returns results as expected, and can thus be used by GitHub actions to
+# periodically verify that our server is still up and running
+
+# How long should a call to the CLI take before we mark it as slow? (in seconds)
+RUNTIME_TRESHOLD="1.0"
+
+RESULTS=$(unipept taxa2tree 14 78 56 38 --format url)
+
+# Check that the command returns a valid URL
+if ! [[ $RESULTS =~ bl\.ocks\.org ]]
+then
+  exit 1
+fi
+
+# Check timing of specific results
+TIMEFORMAT=%R
+RUNTIME=$(time unipept pept2taxa AAAAALTER)
+
+if [[ $(echo "$RUNTIME > $RUNTIME_TRESHOLD" | bc -l) ]]
+then
+  exit 1
+fi
+
+# All is well!
+exit 0

--- a/test/uptime/check_uptime_api.sh
+++ b/test/uptime/check_uptime_api.sh
@@ -5,7 +5,7 @@ set -e
 set -o pipefail
 
 # How long should a call to the CLI take before we mark it as slow? (in seconds)
-RUNTIME_TRESHOLD="1.0"
+RUNTIME_TRESHOLD="2.0"
 
 RESULTS=$(unipept taxa2tree 14 78 56 38 --format url)
 
@@ -15,6 +15,7 @@ then
   exit 1
 fi
 
+TIMEFORMAT=%R
 # Check timing of specific results
 RUNTIME=$(time unipept pept2taxa AAAAALTER &> /dev/null)
 

--- a/test/uptime/check_uptime_api.sh
+++ b/test/uptime/check_uptime_api.sh
@@ -5,19 +5,22 @@ set -e
 set -o pipefail
 
 # How long should a call to the CLI take before we mark it as slow? (in seconds)
-RUNTIME_TRESHOLD="2.0"
+RUNTIME_TRESHOLD="10"
 
-RESULTS=$(unipept taxa2tree 14 78 56 38 --format url)
+RESULTS=$(curl -s --request GET "api.unipept.ugent.be/api/v1/taxa2tree.json?input[]=87&input[]=45&input[]=65&link=true&delete=true")
 
 # Check that the command returns a valid URL
-if ! [[ $RESULTS =~ bl\.ocks\.org ]]
+if ! [[ $RESULTS =~ gist\.github\.com ]]
 then
   exit 1
 fi
 
-TIMEFORMAT=%R
 # Check timing of specific results
-RUNTIME=$(time unipept pept2taxa AAAAALTER &> /dev/null)
+START=$(date +%s)
+curl -s --request GET "http://api.unipept.ugent.be/api/v1/taxa2tree.json?input[]=AAAALTER" &> /dev/null
+END=$(date +%s)
+
+RUNTIME=$((END-START))
 
 if [[ $(echo "$RUNTIME > $RUNTIME_TRESHOLD" | bc -l) ]]
 then

--- a/test/uptime/check_uptime_api.sh
+++ b/test/uptime/check_uptime_api.sh
@@ -1,6 +1,9 @@
 # This script checks if the API-server returns results as expected, and can thus be used by GitHub actions to
 # periodically verify that our server is still up and running
 
+set -e
+set -o pipefail
+
 # How long should a call to the CLI take before we mark it as slow? (in seconds)
 RUNTIME_TRESHOLD="1.0"
 
@@ -15,6 +18,9 @@ fi
 # Check timing of specific results
 TIMEFORMAT=%R
 RUNTIME=$(time unipept pept2taxa AAAAALTER)
+
+bc --version
+echo "$RUNTIME > $RUNTIME_TRESHOLD"
 
 if [[ $(echo "$RUNTIME > $RUNTIME_TRESHOLD" | bc -l) ]]
 then

--- a/test/uptime/check_uptime_api.sh
+++ b/test/uptime/check_uptime_api.sh
@@ -16,11 +16,7 @@ then
 fi
 
 # Check timing of specific results
-TIMEFORMAT=%R
-RUNTIME=$(time unipept pept2taxa AAAAALTER)
-
-bc --version
-echo "$RUNTIME > $RUNTIME_TRESHOLD"
+RUNTIME=$(time unipept pept2taxa AAAAALTER &> /dev/null)
 
 if [[ $(echo "$RUNTIME > $RUNTIME_TRESHOLD" | bc -l) ]]
 then


### PR DESCRIPTION
This PR adds a new GitHub action that is automatically run every hour and checks the uptime of the API-server. It fails if a request does not return the expected results or if a requests takes longer than 10 seconds to execute.

A new flag for the `taxa2tree` command has been added (`remove`), which will automatically remove a newly created gist.