### PR TITLE
speedup pept2taxa

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -66,7 +66,7 @@ class Api::ApiController < ApplicationController
     lookup = Hash.new { |h, k| h[k] = Set.new }
     ids = Set.new
 
-    seqid2seq = Hash.new
+    seqid2seq = {}
     Sequence.where(sequence: @input).select(:id, :sequence).each do |seq|
       seqid2seq[seq[:id]] = seq[:sequence]
       @result[seq[:sequence]] = Set.new

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -5,7 +5,7 @@ server 'morty.ugent.be', user: 'unipept', roles: %i[web app], ssh_options: {
   port: 4840
 }
 
-set :branch, 'feature/unipept-web-components-0.2'
+set :branch, 'fix/speedup-pept2taxa'
 set :rails_env, :production
 
 # Perform yarn install before precompiling the assets in order to pass the


### PR DESCRIPTION
This PR splits a very large and slow query in the `pept2taxa` API-endpoint into multiple small queries to speed up the processing of these queries.