### PR TITLE
Split API checks over multiple file

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -6,7 +6,7 @@ on:
     - cron:  '0 * * * *'
 
 jobs:
-  uptime:
+  api_available:
     runs-on: ubuntu-latest
     steps:
       - name: Install required utilities
@@ -17,5 +17,19 @@ jobs:
       - name: Run uptime check
         shell: bash
         run: |
-          chmod u+x ./test/uptime/check_uptime_api.sh
-          ./test/uptime/check_uptime_api.sh
+          chmod u+x ./test/uptime/check_api_response.sh
+          ./test/uptime/check_api_response.sh
+
+  api_performance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install required utilities
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install bc
+      - uses: actions/checkout@v2
+      - name: Run performance
+        shell: bash
+        run: |
+          chmod u+x ./test/uptime/check_api_performance.sh
+          ./test/uptime/check_api_performance.sh

--- a/test/uptime/check_api_response.sh
+++ b/test/uptime/check_api_response.sh
@@ -4,28 +4,12 @@
 set -e
 set -o pipefail
 
-# How long should a call to the CLI take before we mark it as slow? (in seconds)
-RUNTIME_TRESHOLD="10"
-
 RESULTS=$(curl -s --request GET "api.unipept.ugent.be/api/v1/taxa2tree.json?input[]=87&input[]=45&input[]=65&link=true&delete=true")
 
 # Check that the command returns a valid URL
 if ! [[ $RESULTS =~ gist\.github\.com ]]
 then
   echo "Taxa2Tree did not return a valid URL." >&2
-  exit 1
-fi
-
-# Check timing of specific results
-START=$(date +%s)
-curl -s --request GET "http://api.unipept.ugent.be/api/v1/taxa2tree.json?input[]=AAAALTER" &> /dev/null
-END=$(date +%s)
-
-RUNTIME=$((END-START))
-
-if [[ $(echo "$RUNTIME > $RUNTIME_TRESHOLD" | bc -l) ]]
-then
-  echo "Server seems to be slow." >&2
   exit 1
 fi
 

--- a/test/uptime/check_uptime_performance.sh
+++ b/test/uptime/check_uptime_performance.sh
@@ -1,0 +1,24 @@
+# This script checks if the API-server returns results as expected, and can thus be used by GitHub actions to
+# periodically verify that our server is still up and running
+
+set -e
+set -o pipefail
+
+# How long should a call to the CLI take before we mark it as slow? (in seconds)
+RUNTIME_TRESHOLD="30"
+
+# Check timing of specific results
+START=$(date +%s)
+curl -s --request GET "http://api.unipept.ugent.be/api/v1/taxa2tree.json?input[]=AAAALTER" &> /dev/null
+END=$(date +%s)
+
+RUNTIME=$((END-START))
+
+if [[ $(echo "$RUNTIME > $RUNTIME_TRESHOLD" | bc -l) ]]
+then
+  echo "It took $RUNTIME seconds for the server to produce a valid response." >&2
+  exit 1
+fi
+
+# All is well!
+exit 0


### PR DESCRIPTION
This PR splits the GitHub workflow to check the API-server's up status over 2 jobs: one job that checks the response from the server and one job that checks the performance of the server. This way, e-mail notifications of a failure are more clear and don't require manually checking the job output for which part of the check failed.