### PR TITLE
Fix undefined method upcase for private_api/proteins

### DIFF
--- a/app/controllers/private_api_controller.rb
+++ b/app/controllers/private_api_controller.rb
@@ -25,8 +25,8 @@ class PrivateApiController < HandleOptionsController
 
   def proteins
     unless params[:peptide]
-      @error_name = "Invalid peptide provided"
-      @error_message = "No peptide sequence was provided. Please provide a valid peptide sequence."
+      @error_name = 'Invalid peptide provided'
+      @error_message = 'No peptide sequence was provided. Please provide a valid peptide sequence.'
       render 'private_api/error'
       return
     end
@@ -41,9 +41,9 @@ class PrivateApiController < HandleOptionsController
       # process the input, convert seq to a valid @sequence
       sequence = Sequence.single_search(seq, equate_il)
       @original_sequence = seq
-    rescue SequenceTooShortError => ex
-      @error_name = "Sequence too short"
-      @error_message = "The peptide sequence you provided is too short. It should contain at least 5 valid amino acids."
+    rescue SequenceTooShortError
+      @error_name = 'Sequence too short'
+      @error_message = 'The peptide sequence you provided is too short. It should contain at least 5 valid amino acids.'
       render 'private_api/error'
       return
     end

--- a/app/controllers/private_api_controller.rb
+++ b/app/controllers/private_api_controller.rb
@@ -24,15 +24,29 @@ class PrivateApiController < HandleOptionsController
   end
 
   def proteins
+    unless params[:peptide]
+      @error_name = "Invalid peptide provided"
+      @error_message = "No peptide sequence was provided. Please provide a valid peptide sequence."
+      render 'private_api/error'
+      return
+    end
+
     # process parameters
     # the sequence or id of the peptide (filter out all characters that are non-ASCII)
     seq = params[:peptide].upcase.gsub(/\P{ASCII}/, '')
     # should we equate I and L? (true by default)
     equate_il = params.key?(:equate_il) ? params[:equate_il] : true
 
-    # process the input, convert seq to a valid @sequence
-    sequence = Sequence.single_search(seq, equate_il)
-    @original_sequence = seq
+    begin
+      # process the input, convert seq to a valid @sequence
+      sequence = Sequence.single_search(seq, equate_il)
+      @original_sequence = seq
+    rescue SequenceTooShortError => ex
+      @error_name = "Sequence too short"
+      @error_message = "The peptide sequence you provided is too short. It should contain at least 5 valid amino acids."
+      render 'private_api/error'
+      return
+    end
 
     if sequence.present? && sequence.peptides(equate_il).empty?
       @entries = []

--- a/app/views/private_api/error.json.jbuilder
+++ b/app/views/private_api/error.json.jbuilder
@@ -1,0 +1,2 @@
+json.name @error_name
+json.message @error_message


### PR DESCRIPTION
If no valid peptide sequence is provided to the `private_api/proteins` endpoint, an exception is generated. This pull request correctly catches this exception and instead generates a proper error message. 

This PR should make sure that we no longer receive error messages from the production server when someone (e.g. a bot) performs a request to `/private_api/proteins` with invalid input data.