### PR TITLE
Add v2 of the API with new ranks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,7 +161,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -290,6 +290,9 @@ class Api::ApiController < ApplicationController
 
   # handles the parameters
   def set_params
+    # is the user using v1 of the API or v2?
+    @v1 = request.env['PATH_INFO'].include? 'v1'
+
     unsafe_hash = params.to_unsafe_h
     @input = unsafe_hash[:input]
     if @input.is_a? Hash        # hash

--- a/app/helpers/api_helper.rb
+++ b/app/helpers/api_helper.rb
@@ -1,10 +1,10 @@
 module ApiHelper
   def lineage_info(lineage, include_names = false)
-    if @v1
-      order = Lineage::ORDER_V1
-    else
-      order = Lineage::ORDER
-    end
+    order = if @v1
+              Lineage::ORDER_V1
+            else
+              Lineage::ORDER
+            end
 
     ids = order.map { |o| lineage.try(o) }
     ids = ids.map { |i| i.nil? || i == -1 ? nil : i.abs }

--- a/app/helpers/api_helper.rb
+++ b/app/helpers/api_helper.rb
@@ -1,11 +1,17 @@
 module ApiHelper
   def lineage_info(lineage, include_names = false)
-    ids = Lineage::ORDER.map { |o| lineage.try(o) }
+    if @v1
+      order = Lineage::ORDER_V1
+    else
+      order = Lineage::ORDER
+    end
+
+    ids = order.map { |o| lineage.try(o) }
     ids = ids.map { |i| i.nil? || i == -1 ? nil : i.abs }
-    id_names = Lineage::ORDER.map { |s| s == :class_ ? 'class_id' : "#{s}_id" }
+    id_names = order.map { |s| s == :class_ ? 'class_id' : "#{s}_id" }
 
     if include_names
-      names = Lineage::ORDER.map { |s| s == :class_ ? 'class_name' : "#{s}_name" }
+      names = order.map { |s| s == :class_ ? 'class_name' : "#{s}_name" }
       a = names.zip(lineage.to_a)
       b = id_names.zip(ids)
       lineage_info = Hash[b.zip(a).flatten(1)]

--- a/app/models/lineage.rb
+++ b/app/models/lineage.rb
@@ -12,12 +12,10 @@
 #  superclass       :integer
 #  class            :integer
 #  subclass         :integer
-#  infraclass       :integer
 #  superorder       :integer
 #  order            :integer
 #  suborder         :integer
 #  infraorder       :integer
-#  parvorder        :integer
 #  superfamily      :integer
 #  family           :integer
 #  subfamily        :integer
@@ -29,6 +27,7 @@
 #  species_subgroup :integer
 #  species          :integer
 #  subspecies       :integer
+#  strain           :integer
 #  varietas         :integer
 #  forma            :integer
 #
@@ -48,12 +47,10 @@ class Lineage < ApplicationRecord
   belongs_to :superclass_t,       foreign_key: 'superclass',    primary_key: 'id',  class_name: 'Taxon'
   belongs_to :class_t,            foreign_key: 'class',         primary_key: 'id',  class_name: 'Taxon'
   belongs_to :subclass_t,         foreign_key: 'subclass',      primary_key: 'id',  class_name: 'Taxon'
-  belongs_to :infraclass_t,       foreign_key: 'infraclass',    primary_key: 'id',  class_name: 'Taxon'
   belongs_to :superorder_t,       foreign_key: 'superorder',    primary_key: 'id',  class_name: 'Taxon'
   belongs_to :order_t,            foreign_key: 'order',         primary_key: 'id',  class_name: 'Taxon'
   belongs_to :suborder_t,         foreign_key: 'suborder',      primary_key: 'id',  class_name: 'Taxon'
   belongs_to :infraorder_t,       foreign_key: 'infraorder',    primary_key: 'id',  class_name: 'Taxon'
-  belongs_to :parvorder_t,        foreign_key: 'parvorder',     primary_key: 'id',  class_name: 'Taxon'
   belongs_to :superfamily_t,      foreign_key: 'superfamily',   primary_key: 'id',  class_name: 'Taxon'
   belongs_to :family_t,           foreign_key: 'family',        primary_key: 'id',  class_name: 'Taxon'
   belongs_to :subfamily_t,        foreign_key: 'subfamily',     primary_key: 'id',  class_name: 'Taxon'
@@ -65,16 +62,30 @@ class Lineage < ApplicationRecord
   belongs_to :species_subgroup_t, foreign_key: 'species_subgroup', primary_key: 'id', class_name: 'Taxon'
   belongs_to :species_t,          foreign_key: 'species',       primary_key: 'id',  class_name: 'Taxon'
   belongs_to :subspecies_t,       foreign_key: 'subspecies',    primary_key: 'id',  class_name: 'Taxon'
+  belongs_to :strain_t,           foreign_key: 'strain',        primary_key: 'id',  class_name: 'Taxon'
   belongs_to :varietas_t,         foreign_key: 'varietas',      primary_key: 'id',  class_name: 'Taxon'
   belongs_to :forma_t,            foreign_key: 'forma',         primary_key: 'id',  class_name: 'Taxon'
 
   ORDER = %i[superkingdom kingdom subkingdom superphylum phylum subphylum
+             superclass class_ subclass superorder order suborder
+             infraorder superfamily family subfamily tribe
+             subtribe genus subgenus species_group species_subgroup
+             species subspecies strain varietas forma].freeze
+
+  ORDER_T = %i[superkingdom_t kingdom_t subkingdom_t superphylum_t phylum_t
+               subphylum_t superclass_t class_t subclass_t
+               superorder_t order_t suborder_t infraorder_t superfamily_t
+               family_t subfamily_t tribe_t subtribe_t genus_t subgenus_t
+               species_group_t species_subgroup_t species_t subspecies_t strain_t
+               varietas_t forma_t].freeze
+
+  ORDER_V1 = %i[superkingdom kingdom subkingdom superphylum phylum subphylum
              superclass class_ subclass infraclass superorder order suborder
              infraorder parvorder superfamily family subfamily tribe
              subtribe genus subgenus species_group species_subgroup
              species subspecies varietas forma].freeze
 
-  ORDER_T = %i[superkingdom_t kingdom_t subkingdom_t superphylum_t phylum_t
+  ORDER_V1_T = %i[superkingdom_t kingdom_t subkingdom_t superphylum_t phylum_t
                subphylum_t superclass_t class_t subclass_t infraclass_t
                superorder_t order_t suborder_t infraorder_t parvorder_t superfamily_t
                family_t subfamily_t tribe_t subtribe_t genus_t subgenus_t
@@ -83,7 +94,7 @@ class Lineage < ApplicationRecord
 
   scope :with_names, -> { includes(ORDER_T) }
 
-  # rails 4.2+ checks the values befor using them in queries
+  # rails 4.2+ checks the values before using them in queries
   # Eager loading the Taxa results in a range error if there are -1 values
   # http://metaskills.net/2015/01/06/activerecord-42s-type-casting/
   # This code disables the rangecheck for UnsignedIntegers

--- a/app/models/lineage.rb
+++ b/app/models/lineage.rb
@@ -80,17 +80,17 @@ class Lineage < ApplicationRecord
                varietas_t forma_t].freeze
 
   ORDER_V1 = %i[superkingdom kingdom subkingdom superphylum phylum subphylum
-             superclass class_ subclass infraclass superorder order suborder
-             infraorder parvorder superfamily family subfamily tribe
-             subtribe genus subgenus species_group species_subgroup
-             species subspecies varietas forma].freeze
+                superclass class_ subclass infraclass superorder order suborder
+                infraorder parvorder superfamily family subfamily tribe
+                subtribe genus subgenus species_group species_subgroup
+                species subspecies varietas forma].freeze
 
   ORDER_V1_T = %i[superkingdom_t kingdom_t subkingdom_t superphylum_t phylum_t
-               subphylum_t superclass_t class_t subclass_t infraclass_t
-               superorder_t order_t suborder_t infraorder_t parvorder_t superfamily_t
-               family_t subfamily_t tribe_t subtribe_t genus_t subgenus_t
-               species_group_t species_subgroup_t species_t subspecies_t
-               varietas_t forma_t].freeze
+                  subphylum_t superclass_t class_t subclass_t infraclass_t
+                  superorder_t order_t suborder_t infraorder_t parvorder_t superfamily_t
+                  family_t subfamily_t tribe_t subtribe_t genus_t subgenus_t
+                  species_group_t species_subgroup_t species_t subspecies_t
+                  varietas_t forma_t].freeze
 
   scope :with_names, -> { includes(ORDER_T) }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,21 @@ UnipeptWeb::Application.routes.draw do
     match 'messages' => 'api#messages', via: %i[get post]
   end
 
+  namespace :api, path: 'api/v2' do
+    match 'pept2taxa' => "api#pept2taxa", via: %i[get post]
+    match 'pept2lca' => "api#pept2lca", via: %i[get post]
+    match 'taxa2lca' => 'api#taxa2lca', via: %i[get post]
+    match 'pept2prot' => 'api#pept2prot', via: %i[get post]
+    match 'pept2funct' => 'api#pept2funct', via: %i[get post]
+    match 'pept2ec' => 'api#pept2ec', via: %i[get post]
+    match 'pept2go' => 'api#pept2go', via: %i[get post]
+    match 'pept2interpro' => 'api#pept2interpro', via: %i[get post]
+    match 'taxa2tree' => 'api#taxa2tree', via: %i[get post]
+    match 'peptinfo' => 'api#peptinfo', via: %i[get post]
+    match 'taxonomy' => 'api#taxonomy', via: %i[get post]
+    match 'messages' => 'api#messages', via: %i[get post]
+  end
+
   # API docs
   namespace :api, path: 'apidocs' do
     get '/',          to: 'apidocs#index',      as: 'apidocs'

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -11,8 +11,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: ["app/assets"]
-  additional_paths: ["app/assets/javascripts"]
+  additional_paths: ["app/assets", "app/assets/javascripts"]
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,12 +75,10 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer "superclass", limit: 3
     t.integer "class", limit: 3
     t.integer "subclass", limit: 3
-    t.integer "infraclass", limit: 3
     t.integer "superorder", limit: 3
     t.integer "order", limit: 3
     t.integer "suborder", limit: 3
     t.integer "infraorder", limit: 3
-    t.integer "parvorder", limit: 3
     t.integer "superfamily", limit: 3
     t.integer "family", limit: 3
     t.integer "subfamily", limit: 3
@@ -92,6 +90,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer "species_subgroup", limit: 3
     t.integer "species", limit: 3
     t.integer "subspecies", limit: 3
+    t.integer "strain", limit: 3
     t.integer "varietas", limit: 3
     t.integer "forma", limit: 3
   end

--- a/test/controllers/private_api_controller_test.rb
+++ b/test/controllers/private_api_controller_test.rb
@@ -6,7 +6,7 @@ class PrivateApiControllerTest < ActionController::TestCase
     post :taxa, params: { taxids: [1, 2, 3] }
     assert_response :success
     assert_template :taxa
-    assert_equal JSON.parse('[{"id":1, "name":"species1", "rank":"species", "lineage":[null, 2, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, 1, null, null, null]}, {"id":2, "name":"kingdom1", "rank":"kingdom", "lineage":[null, 2, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null]}]'), JSON.parse(response.body)
+    assert_equal JSON.parse('[{"id":1, "name":"species1", "rank":"species", "lineage":[null, 2, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, 1, null, null, null, null]}, {"id":2, "name":"kingdom1", "rank":"kingdom", "lineage":[null, 2, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null]}]'), JSON.parse(response.body)
   end
 
   test 'should get go terms' do

--- a/test/fixtures/lineages.yml
+++ b/test/fixtures/lineages.yml
@@ -12,12 +12,10 @@
 #  superclass       :integer
 #  class            :integer
 #  subclass         :integer
-#  infraclass       :integer
 #  superorder       :integer
 #  order            :integer
 #  suborder         :integer
 #  infraorder       :integer
-#  parvorder        :integer
 #  superfamily      :integer
 #  family           :integer
 #  subfamily        :integer
@@ -29,6 +27,7 @@
 #  species_subgroup :integer
 #  species          :integer
 #  subspecies       :integer
+#  strain           :integer
 #  varietas         :integer
 #  forma            :integer
 #

--- a/test/models/lineage_test.rb
+++ b/test/models/lineage_test.rb
@@ -12,12 +12,10 @@
 #  superclass       :integer
 #  class            :integer
 #  subclass         :integer
-#  infraclass       :integer
 #  superorder       :integer
 #  order            :integer
 #  suborder         :integer
 #  infraorder       :integer
-#  parvorder        :integer
 #  superfamily      :integer
 #  family           :integer
 #  subfamily        :integer
@@ -29,6 +27,7 @@
 #  species_subgroup :integer
 #  species          :integer
 #  subspecies       :integer
+#  strain           :integer
 #  varietas         :integer
 #  forma            :integer
 #
@@ -71,8 +70,6 @@ class LineageTest < ActiveSupport::TestCase
     lineage.next_t
     assert_equal 4, lineage.get_iterator_position
     lineage.set_iterator_position(27)
-    assert lineage.has_next?
-    lineage.set_iterator_position(28)
     assert_not lineage.has_next?
   end
 
@@ -87,7 +84,7 @@ class LineageTest < ActiveSupport::TestCase
 
   test 'should give correct result for to_a' do
     lineage = lineages(:lineage1)
-    array = ['', 'kingdom1', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 'species1', '', '', '']
+    array = ['', 'kingdom1', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', 'species1', '', '', '', '']
     assert_equal array, lineage.to_a
   end
 


### PR DESCRIPTION
This PR adds a new v2 of the Unipept API that differs in the ranks that are returned when requesting lineage information for a peptide.

Example for `api/v1/pept2taxa.json?input[]=MHEMSIAEGIVQLLEEQAAAQR&extra=true`:

```
[
    {
        "peptide": "MHEMSIAEGIVQLLEEQAAAQR",
        "taxon_id": 355,
        "taxon_name": "Azotobacter chroococcum (strain mcd 1)",
        "taxon_rank": "strain",
        "superkingdom_id": 2,
        "kingdom_id": null,
        "subkingdom_id": null,
        "superphylum_id": null,
        "phylum_id": 1224,
        "subphylum_id": null,
        "superclass_id": null,
        "class_id": 1236,
        "subclass_id": null,
        "infraclass_id": null,
        "superorder_id": null,
        "order_id": 72274,
        "suborder_id": null,
        "infraorder_id": null,
        "parvorder_id": null,
        "superfamily_id": null,
        "family_id": 135621,
        "subfamily_id": 351,
        "tribe_id": null,
        "subtribe_id": null,
        "genus_id": 352,
        "subgenus_id": null,
        "species_group_id": null,
        "species_subgroup_id": null,
        "species_id": 353,
        "subspecies_id": null,
        "varietas_id": null,
        "forma_id": null
    }
]
```

Example for `api/v2/pept2taxa.json?input[]=MHEMSIAEGIVQLLEEQAAAQR&extra=true`:

```
[
    {
        "peptide": "MHEMSIAEGIVQLLEEQAAAQR",
        "taxon_id": 355,
        "taxon_name": "Azotobacter chroococcum (strain mcd 1)",
        "taxon_rank": "strain",
        "superkingdom_id": 2,
        "kingdom_id": null,
        "subkingdom_id": null,
        "superphylum_id": null,
        "phylum_id": 1224,
        "subphylum_id": null,
        "superclass_id": null,
        "class_id": 1236,
        "subclass_id": null,
        "superorder_id": null,
        "order_id": 72274,
        "suborder_id": null,
        "infraorder_id": null,
        "superfamily_id": null,
        "family_id": 135621,
        "subfamily_id": 351,
        "tribe_id": null,
        "subtribe_id": null,
        "genus_id": 352,
        "subgenus_id": null,
        "species_group_id": null,
        "species_subgroup_id": null,
        "species_id": 353,
        "subspecies_id": null,
        "strain_id": 355,
        "varietas_id": null,
        "forma_id": null
    }
]
```

Notice that the `strain_id` has been added in v2 and that some of the other ranks have been removed (e.g. `parvorder`).