### PR TITLE
Increase key space limit for larger requests

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -48,7 +48,7 @@ module UnipeptWeb
 
     # Increase key space limit to allow for larger requests to succeed (which is for example required by large requests
     # to taxa2tree)
-    Rack::Utils.key_space_limit = 1048576
+    Rack::Utils.key_space_limit = 10485760
 
     MultiJson.use :Oj
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,10 @@ module UnipeptWeb
 
     config.api_host = 'api.unipept.ugent.be'
 
+    # Increase key space limit to allow for larger requests to succeed (which is for example required by large requests
+    # to taxa2tree)
+    Rack::Utils.key_space_limit = 1048576
+
     MultiJson.use :Oj
   end
 end


### PR DESCRIPTION
This PR increases the `key_space_limit` in order to allow large requests to our API to succeed.