### PR TITLE
Peptidome add warning

### DIFF
--- a/app/views/peptidome/analyze.html.erb
+++ b/app/views/peptidome/analyze.html.erb
@@ -3,8 +3,7 @@
 <% end %>
 
 <div class="alert alert-warning" role="alert">
-  <strong>Notice: </strong> the peptidome analysis has been a part of Unipept for several years now. Recently, changes in most modern browsers require us to rework most of this peptidome clustering application. This is, unfortunately, not feasible for us at the moment and lead us
-  to the decision of ending support for the Unipept peptidome analysis soon. Please <a href="mailto:unipept@ugent.be" class="alert-link">contact us</a> in case you have any concerns or questions regarding this statement.
+  <strong>Notice:</strong> Due to a combination of changes both in modern browsers and at the source data, we're having a hard time keeping the unique peptide finder and clustering up and running. We therefore plan on retiring this feature by the end of this year. If you are still using the unique peptide finder or clustering, please contact us at <a href="mailto:unipept@ugent.be" class="alert-link">unipept@ugent.be</a> so we can work towards an alternative solution.
 </div>
 
 <h1>Peptidome Analysis</h1>

--- a/app/views/peptidome/analyze.html.erb
+++ b/app/views/peptidome/analyze.html.erb
@@ -2,6 +2,11 @@
   <%= javascript_pack_tag 'pancore' %>
 <% end %>
 
+<div class="alert alert-warning" role="alert">
+  <strong>Notice: </strong> the peptidome analysis has been a part of Unipept for several years now. Recently, changes in most modern browsers require us to rework most of this peptidome clustering application. This is, unfortunately, not feasible for us at the moment and lead us
+  to the decision of ending support for the Unipept peptidome analysis soon. Please <a href="mailto:unipept@ugent.be" class="alert-link">contact us</a> in case you have any concerns or questions regarding this statement.
+</div>
+
 <h1>Peptidome Analysis</h1>
 <p>The (tryptic) peptidome is the complete set of (tryptic) peptides encoded in the proteome of an organism. Unipept provides fast and flexible analysis tools for identifying the unique peptidome of a given taxon and peptidome-based clustering.</p>
 <div class='card card-nav'>


### PR DESCRIPTION
This PR adds a new banner to the peptidome analysis page that informs the user about stopping support for the peptidome cluster analysis in the near future.

Screenshot:

![image](https://user-images.githubusercontent.com/9608686/132646417-4cf9f367-0d81-434a-b447-865dbc8b2065.png)
