### PR TITLE
Update API URL and decrease parallel API requests

### DIFF
--- a/app/assets/javascripts/mpa/components/App.vue
+++ b/app/assets/javascripts/mpa/components/App.vue
@@ -46,7 +46,7 @@ export default class App extends Vue {
 
     async mounted() {
         this.loading = true;
-        NetworkConfiguration.BASE_URL = "https://unipept.ugent.be";
+        NetworkConfiguration.BASE_URL = "https://api.unipept.ugent.be";
         QueueManager.initializeQueue(4);
         await this.readStoredAssays();
         this.loading = false;

--- a/app/assets/javascripts/mpa/components/App.vue
+++ b/app/assets/javascripts/mpa/components/App.vue
@@ -47,6 +47,7 @@ export default class App extends Vue {
     async mounted() {
         this.loading = true;
         NetworkConfiguration.BASE_URL = "https://api.unipept.ugent.be";
+        NetworkConfiguration.PARALLEL_API_REQUESTS = 2;
         QueueManager.initializeQueue(4);
         await this.readStoredAssays();
         this.loading = false;

--- a/app/assets/javascripts/spa/components/SingleResults.vue
+++ b/app/assets/javascripts/spa/components/SingleResults.vue
@@ -41,7 +41,7 @@ export default class SingleResults extends Vue {
     private communicationSource: CommunicationSource = new DefaultCommunicationSource();
 
     private created() {
-        NetworkConfiguration.BASE_URL = "";
+        NetworkConfiguration.BASE_URL = "https://api.unipept.ugent.be";
         QueueManager.initializeQueue(4);
 
         const currentRoute: string = window.location.href;

--- a/config/deploy/feat.rb
+++ b/config/deploy/feat.rb
@@ -1,30 +1,14 @@
-set :stage, :feat
+set :stage, :prod
 
-set :deploy_to, '/home/bmesuere/rails'
+set :deploy_to, '/home/unipept/rails'
 
 # don't specify db as it's not needed for unipept
-server 'morty.ugent.be', user: 'unipept', roles: %i[web app], ssh_options: {
-  port: 4840
+server 'unipeptweb.ugent.be', user: 'unipept', roles: %i[web app], ssh_options: {
+  port: 22
 }
 
-set :branch, 'documentation/unipept-desktop'
+set :branch, 'fix/update_api_url'
 set :rails_env, :production
-
-# Perform yarn install before precompiling the assets in order to pass the
-# integrity check.
-namespace :deploy do
-  namespace :assets do
-    before :precompile, :yarn_install do
-      on release_roles(fetch(:assets_roles)) do
-        within release_path do
-          with rails_env: fetch(:rails_env) do
-            execute :yarn, "install"
-          end
-        end
-      end
-    end
-  end
-end
 
 namespace :deploy do
   before :publishing, :asset_stuff do

--- a/config/deploy/feat.rb
+++ b/config/deploy/feat.rb
@@ -1,14 +1,30 @@
-set :stage, :prod
+set :stage, :feat
 
-set :deploy_to, '/home/unipept/rails'
+set :deploy_to, '/home/bmesuere/rails'
 
 # don't specify db as it's not needed for unipept
-server 'unipeptweb.ugent.be', user: 'unipept', roles: %i[web app], ssh_options: {
-  port: 22
+server 'morty.ugent.be', user: 'unipept', roles: %i[web app], ssh_options: {
+  port: 4840
 }
 
-set :branch, 'fix/update_api_url'
+set :branch, 'documentation/unipept-desktop'
 set :rails_env, :production
+
+# Perform yarn install before precompiling the assets in order to pass the
+# integrity check.
+namespace :deploy do
+  namespace :assets do
+    before :precompile, :yarn_install do
+      on release_roles(fetch(:assets_roles)) do
+        within release_path do
+          with rails_env: fetch(:rails_env) do
+            execute :yarn, "install"
+          end
+        end
+      end
+    end
+  end
+end
 
 namespace :deploy do
   before :publishing, :asset_stuff do


### PR DESCRIPTION
This PR updates the API URL that's being used under-the-hood to `https://api.unipept.ugent.be`, preparing our application for the changes we are currently making to our server infrastructure.

We've also updated the amount of API requests that are performed in parallel to 2 (instead of 5) in order to decrease the load spikes on our servers.