### PR TITLE
Add GitHub action that automatically deploys new versions of web app

### DIFF
--- a/.github/workflows/deploy_action.yml
+++ b/.github/workflows/deploy_action.yml
@@ -4,25 +4,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to deploy (commit tag version is used if not specified)'
-        required: false
 
 jobs:
   deploy-web:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set version identifier if not specified
-      if: ${{ github.event.inputs.version == "" }}
-      id: vars
-      run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-    - name: Set version identifier if specified
-      if: ${{ github.event.inputs.version != "" }}
-      id: vars
-      run: echo "tag=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
     - name: Install SSH key
       uses: shimataro/ssh-key-action@v2
       with:
@@ -30,4 +17,4 @@ jobs:
         known_hosts: ${{ secrets.KNOWN_HOSTS }}
     - name: Start deploying requested version
       run: |
-        echo "deploy web v${{ steps.vars.outputs.tag }}" | ssh -p 4840 unipept@unipeptapi.ugent.be
+        echo "deploy web $GITHUB_SHA" | ssh -p 4840 unipept@unipeptapi.ugent.be

--- a/.github/workflows/deploy_action.yml
+++ b/.github/workflows/deploy_action.yml
@@ -1,0 +1,33 @@
+name: Deploy Unipept Web
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (commit tag version is used if not specified)'
+        required: false
+
+jobs:
+  deploy-web:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set version identifier if not specified
+      if: ${{ github.event.inputs.version == "" }}
+      id: vars
+      run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+    - name: Set version identifier if specified
+      if: ${{ github.event.inputs.version != "" }}
+      id: vars
+      run: echo "tag=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+    - name: Install SSH key
+      uses: shimataro/ssh-key-action@v2
+      with:
+        key: ${{ secrets.SSH_KEY }}
+        known_hosts: ${{ secrets.KNOWN_HOSTS }}
+    - name: Start deploying requested version
+      run: |
+        echo "deploy web v${{ steps.vars.outputs.tag }}" | ssh -p 4840 unipept@unipeptapi.ugent.be


### PR DESCRIPTION
This PR adds a new GitHub action that can be used to automatically deploy the latest version of the Unipept Web application after a new release has been published for this repository.