### PR TITLE
Bump unipept-web-components dependency to v2.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "unipept-web",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "unipept-web",
-      "version": "5.0.7",
+      "version": "5.0.8",
       "dependencies": {
         "@vueuse/core": "^9.13.0",
         "core-js": "^3.29.0",
         "pinia": "^2.0.33",
-        "unipept-web-components": "^2.0.5",
+        "unipept-web-components": "^2.0.6",
         "uuid": "^9.0.0",
         "vue": "^2.7.14",
         "vue-router": "^3.6.5",
@@ -12339,9 +12339,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/unipept-web-components": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-2.0.5.tgz",
-      "integrity": "sha512-Q0bdcm368n5VImkXgsCg5D5tVeBsCqqvND5ynSGFQlklUPXBF3MGFLd5UlUv2FuGwUCyTqB7uj0iyIJLcn/VhA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-2.0.6.tgz",
+      "integrity": "sha512-eJiv3jW2PxEspIpfKv4FsO7Nw5CXkOf5D/VSGvVQiWr36TGqu31U3UHRMqBbYsdxyLSInfoY1cIXBQRjSK7J6w==",
       "dependencies": {
         "async": "^3.2.4",
         "canvg": "^4.0.1",
@@ -22721,9 +22721,9 @@
       }
     },
     "unipept-web-components": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-2.0.5.tgz",
-      "integrity": "sha512-Q0bdcm368n5VImkXgsCg5D5tVeBsCqqvND5ynSGFQlklUPXBF3MGFLd5UlUv2FuGwUCyTqB7uj0iyIJLcn/VhA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-2.0.6.tgz",
+      "integrity": "sha512-eJiv3jW2PxEspIpfKv4FsO7Nw5CXkOf5D/VSGvVQiWr36TGqu31U3UHRMqBbYsdxyLSInfoY1cIXBQRjSK7J6w==",
       "requires": {
         "async": "^3.2.4",
         "canvg": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@vueuse/core": "^9.13.0",
     "core-js": "^3.29.0",
     "pinia": "^2.0.33",
-    "unipept-web-components": "^2.0.5",
+    "unipept-web-components": "^2.0.6",
     "uuid": "^9.0.0",
     "vue": "^2.7.14",
     "vue-router": "^3.6.5",


### PR DESCRIPTION
This PR bumps the Unipept Web Components dependency from v2.0.5 to v2.0.6. A list of all changes can be found [here](https://github.com/unipept/unipept-web-components/releases/tag/v2.0.6).