### PR TITLE
Update URL to Docker guide for increasing volume size

### DIFF
--- a/src/components/pages/desktopdocs/DesktopFAQPage.vue
+++ b/src/components/pages/desktopdocs/DesktopFAQPage.vue
@@ -17,7 +17,7 @@
                 from the previous one to the one. Doing so is, however, quite technical and is not recommended for
                 non-technical users. Instead, we recommend to use a Linux system (such as Ubuntu) or a Mac in this case.
                 If you do want to move the virtual hard drive on Windows, you can follow the steps in
-                <a href="https://learn.microsoft.com/en-us/windows/wsl/vhd-size">this guide</a>.
+                <a href="https://verschaffelt.be/increase-maximum-size-of-docker-volume-on-windows/">this guide</a>.
             </p>
             <h3 class="font-weight-bold">
                 Q: Is Docker always required when using the Unipept Desktop application?


### PR DESCRIPTION
This PR updates the URL in the Unipept Desktop documentation pages to a new guide that more clearly explains how to change the size of the Docker volume on Windows (using WSL 2).