### PR TITLE
Add information about disabling of the missed cleavage option

### DIFF
--- a/src/components/alerts/MissedCleavageAlert.vue
+++ b/src/components/alerts/MissedCleavageAlert.vue
@@ -1,0 +1,21 @@
+<template>
+    <v-alert
+        icon="$info"
+        type="info"
+    >
+      <template #text>
+        <div>
+          Missed cleavage handling is now enabled by default. Because of a change in Unipept's underlying search engine,
+          enabling missed cleavage no longer results in a performance penalty and the configuration option will be removed
+          in a future release. See <a class="text-white" href="https://github.com/unipept/unipept/wiki/Unipept-Next">this page</a>
+          for more information on this change.
+        </div>
+      </template>
+    </v-alert>
+</template>
+
+<style scoped>
+
+</style>
+<script setup lang="ts">
+</script>

--- a/src/components/cards/analysis/multi/AnalysisSummaryCard.vue
+++ b/src/components/cards/analysis/multi/AnalysisSummaryCard.vue
@@ -93,23 +93,23 @@
                     </template>
                 </v-tooltip>
 
-               <missed-cleavage-alert />
-
-                <v-tooltip text="Recombine subpeptides of miscleavages. Enabling this has a serious performance impact!">
-                    <template #activator="{ props }">
-                        <v-switch
-                            :model-value="true"
-                            class="pt-0 mt-0"
-                            density="compact"
-                            hide-details
-                            color="primary"
-                            label="Advanced missed cleavage handling"
-                            v-bind="props"
-                            inset
-                            disabled
-                        />
-                    </template>
-                </v-tooltip>
+                <custom-tooltip style="width: 100%;">
+                    <v-switch
+                        :model-value="true"
+                        class="pt-0 mt-0"
+                        density="compact"
+                        hide-details
+                        color="primary"
+                        inset
+                        disabled
+                    >
+                        <template #label>
+                            <span class="text-black">
+                                Advanced missed cleavage handling <v-icon class="ml-1" icon="$info" />
+                            </span>
+                        </template>
+                    </v-switch>
+                </custom-tooltip>
 
                 <div class="card-actions d-flex flex-wrap justify-center">
                     <v-tooltip text="Restart search with selected samples using the settings chosen above.">
@@ -168,6 +168,7 @@ import useMultiAnalysis from "@/store/MultiAnalysisStore";
 import MissingPeptidesDialog from "@/components/dialogs/MissingPeptidesDialog.vue";
 import { MultiProteomicsAnalysisStatus } from "unipept-web-components";
 import MissedCleavageAlert from "@/components/alerts/MissedCleavageAlert.vue";
+import CustomTooltip from "@/components/cards/analysis/multi/CustomTooltip.vue";
 
 const multiAnalysisStore = useMultiAnalysis();
 

--- a/src/components/cards/analysis/multi/AnalysisSummaryCard.vue
+++ b/src/components/cards/analysis/multi/AnalysisSummaryCard.vue
@@ -93,10 +93,12 @@
                     </template>
                 </v-tooltip>
 
+               <missed-cleavage-alert />
+
                 <v-tooltip text="Recombine subpeptides of miscleavages. Enabling this has a serious performance impact!">
                     <template #activator="{ props }">
                         <v-switch
-                            v-model="cleavageHandling"
+                            :model-value="true"
                             class="pt-0 mt-0"
                             density="compact"
                             hide-details
@@ -104,6 +106,7 @@
                             label="Advanced missed cleavage handling"
                             v-bind="props"
                             inset
+                            disabled
                         />
                     </template>
                 </v-tooltip>
@@ -164,6 +167,7 @@ import { storeToRefs } from "pinia";
 import useMultiAnalysis from "@/store/MultiAnalysisStore";
 import MissingPeptidesDialog from "@/components/dialogs/MissingPeptidesDialog.vue";
 import { MultiProteomicsAnalysisStatus } from "unipept-web-components";
+import MissedCleavageAlert from "@/components/alerts/MissedCleavageAlert.vue";
 
 const multiAnalysisStore = useMultiAnalysis();
 

--- a/src/components/cards/analysis/multi/CustomTooltip.vue
+++ b/src/components/cards/analysis/multi/CustomTooltip.vue
@@ -1,0 +1,111 @@
+<template>
+    <div
+        class="tooltip-wrapper"
+        @mouseenter="startShowTooltipTimer"
+        @mouseleave="cancelShowTooltipTimer"
+    >
+        <slot></slot>
+        <div
+            v-if="visible"
+            class="custom-tooltip"
+            ref="tooltip"
+            @mouseenter="cancelHideTooltipTimer"
+            @mouseleave="startHideTooltipTimer"
+        >
+            Missed cleavage handling is now always enabled. Because of a change in
+            Unipept's underlying search engine, enabling missed cleavage handling no
+            longer results in a performance penalty. As a result, this configuration
+            option will be removed in a future release. See
+            <a
+                href="https://github.com/unipept/unipept/wiki/Unipept-Next"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-white"
+            >this page</a>
+            for more information.
+        </div>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+
+// State variables for tooltip visibility and timers
+const visible = ref(false);
+let showTooltipTimer: number | null = null;
+let hideTooltipTimer: number | null = null;
+
+// Function to start the timer for showing the tooltip
+const startShowTooltipTimer = () => {
+    if (showTooltipTimer !== null) {
+        clearTimeout(showTooltipTimer);
+        showTooltipTimer = null;
+    } // Clear any existing show timer
+    showTooltipTimer = window.setTimeout(() => {
+        visible.value = true;
+    }, 300); // Show tooltip after 200ms
+};
+
+// Function to cancel the show tooltip timer
+const cancelShowTooltipTimer = () => {
+    if (showTooltipTimer !== null) {
+        clearTimeout(showTooltipTimer);
+        showTooltipTimer = null;
+    }
+    startHideTooltipTimer();
+};
+
+// Function to start the timer for hiding the tooltip
+const startHideTooltipTimer = () => {
+    cancelHideTooltipTimer(); // Clear any existing hide timer
+    hideTooltipTimer = window.setTimeout(() => {
+        visible.value = false;
+    }, 1000); // Hide tooltip after 1 second
+};
+
+// Function to cancel the hide tooltip timer
+const cancelHideTooltipTimer = () => {
+    if (hideTooltipTimer !== null) {
+        clearTimeout(hideTooltipTimer);
+        hideTooltipTimer = null;
+    }
+};
+</script>
+
+<style scoped>
+.tooltip-wrapper {
+    position: relative;
+    display: inline-block;
+    overflow: visible; /* Ensure the tooltip is not clipped by the parent */
+}
+
+.custom-tooltip {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #323232;
+    color: #fff;
+    padding: 8px;
+    border-radius: 4px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+    z-index: 1000;
+    margin-bottom: 8px;
+    transition: opacity 0.2s ease-in-out;
+    pointer-events: auto; /* Allows interaction with tooltip content */
+    max-width: 400px; /* Maximum width for the tooltip */
+    width: max-content; /* Ensures tooltip takes the minimum width necessary */
+    overflow: hidden; /* Ensures content doesn't overflow */
+    white-space: normal; /* Allows text to wrap within the tooltip */
+    line-height: 1.4; /* Improves readability with line spacing */
+}
+
+.custom-tooltip a {
+    color: #1e88e5; /* Style for the link */
+    text-decoration: underline;
+}
+
+.custom-tooltip a:hover {
+    color: #1565c0;
+}
+</style>

--- a/src/components/cards/analysis/multi/SelectDatasetCard.vue
+++ b/src/components/cards/analysis/multi/SelectDatasetCard.vue
@@ -83,10 +83,11 @@
                     </template>
                 </v-tooltip>
 
+                <missed-cleavage-alert />
                 <v-tooltip text="Recombine subpeptides of miscleavages. Enabling this has a serious performance impact!">
                     <template #activator="{ props }">
                         <v-switch
-                            v-model="cleavageHandling"
+                            :model-value="true"
                             class="pt-0 mt-0"
                             density="compact"
                             label="Advanced missed cleavage handling"
@@ -94,6 +95,7 @@
                             hide-details
                             color="primary"
                             inset
+                            disabled
                         />
                     </template>
                 </v-tooltip>
@@ -125,6 +127,7 @@ import { ref } from 'vue';
 import { Assay } from "unipept-web-components";
 import AnalyticsCommunicator from '@/logic/communicators/analytics/AnalyticsCommunicator';
 import useMultiAnalysis from "@/store/MultiAnalysisStore";
+import MissedCleavageAlert from "@/components/alerts/MissedCleavageAlert.vue";
 
 const emit = defineEmits(['search']);
 

--- a/src/components/cards/analysis/multi/SelectDatasetCard.vue
+++ b/src/components/cards/analysis/multi/SelectDatasetCard.vue
@@ -83,22 +83,23 @@
                     </template>
                 </v-tooltip>
 
-                <missed-cleavage-alert />
-                <v-tooltip text="Recombine subpeptides of miscleavages. Enabling this has a serious performance impact!">
-                    <template #activator="{ props }">
-                        <v-switch
-                            :model-value="true"
-                            class="pt-0 mt-0"
-                            density="compact"
-                            label="Advanced missed cleavage handling"
-                            v-bind="props"
-                            hide-details
-                            color="primary"
-                            inset
-                            disabled
-                        />
-                    </template>
-                </v-tooltip>
+                <custom-tooltip style="width: 100%;">
+                    <v-switch
+                        :model-value="true"
+                        class="pt-0 mt-0"
+                        density="compact"
+                        hide-details
+                        color="primary"
+                        inset
+                        disabled
+                    >
+                        <template #label>
+                            <span class="text-black">
+                                Advanced missed cleavage handling <v-icon class="ml-1" icon="$info" />
+                            </span>
+                        </template>
+                    </v-switch>
+                </custom-tooltip>
 
                 <div class="d-flex justify-center mt-4">
                     <v-btn
@@ -127,7 +128,7 @@ import { ref } from 'vue';
 import { Assay } from "unipept-web-components";
 import AnalyticsCommunicator from '@/logic/communicators/analytics/AnalyticsCommunicator';
 import useMultiAnalysis from "@/store/MultiAnalysisStore";
-import MissedCleavageAlert from "@/components/alerts/MissedCleavageAlert.vue";
+import CustomTooltip from "@/components/cards/analysis/multi/CustomTooltip.vue";
 
 const emit = defineEmits(['search']);
 
@@ -184,5 +185,8 @@ const dateToString = (date: Date) => {
 }
 .selected-placeholder {
     display: inline-block;
+}
+.v-selection-control--disabled {
+    opacity: 1 !important;
 }
 </style>

--- a/src/components/cards/analysis/multi/SwitchDatasetCard.vue
+++ b/src/components/cards/analysis/multi/SwitchDatasetCard.vue
@@ -84,7 +84,6 @@
 
             <v-divider />
 
-
             <div class="text-center pt-4">
                 <v-tooltip text="Compare samples above using a heatmap.">
                     <template #activator="{ props }">


### PR DESCRIPTION
This PR introduces a new alert that is always shown above the "advanced missed cleavage handling" option. This option is now always enabled and cannot be unchecked anymore (because of the changes made to the index underlying unipept).

The alert is very prominent, but this is by-design. Users do need to know that this change happened. We will eventually remove this option from Unipept entirely, and that's when the alert will be removed as well. A link to a page on the wiki here is provided to explain this change-in-behavior more in-depth.

Screenshot:
![image](https://github.com/user-attachments/assets/fe401279-67b8-482d-b94b-7ed61ef6265c)
