### PR TITLE
Update all publications and the about page

### DIFF
--- a/src/components/pages/AboutPage.vue
+++ b/src/components/pages/AboutPage.vue
@@ -31,6 +31,18 @@
                         </span>
                         <ul class="pl-6">
                             <li>
+                                Unipept in 2024: Vande Moortele et al. (2024)
+                                <RLink to="https://doi.org/10.1101/2024.09.26.615136">
+                                    doi.org/10.1101/2024.09.26.615136
+                                </RLink>
+                            </li>
+                            <li>
+                              Unipept Desktop 2.0: Verschaffelt et al. (2023)
+                              <RLink to="https://doi.org/10.1021/acs.jproteome.3c00091">
+                                  doi.org/10.1021/acs.jproteome.3c00091
+                              </RLink>
+                            </li>
+                            <li>
                                 Unipept Desktop: Verschaffelt et al. (2021)
                                 <RLink to="https://doi.org/10.1021/acs.jproteome.0c00855">
                                     doi.org/10.1021/acs.jproteome.0c00855
@@ -162,9 +174,11 @@ import ugentLogoImage from "@/assets/about/ugent-logo.png";
 const members = [
     { name: "Bart Mesuere", title: "Project lead", imgUrl: "https://avatars.githubusercontent.com/u/481872?v=4" },
     { name: "Pieter Verschaffelt", title: "PostDoc", imgUrl: "https://avatars.githubusercontent.com/u/9608686?v=4" },
+    { name: "Tim Van Den Bossche", title: "PostDoc", imgUrl: "" },
     { name: "Tibo Vande Moortele", title: "PhD student", imgUrl: "https://avatars.githubusercontent.com/u/34175340?v=4" },
-    { name: "Stijn De Clercq", title: "Master student 2023 - 2024", imgUrl: "" },
-    { name: "Bram Devlaminck", title: "Master student 2023 - 2024", imgUrl: "" },
+    { name: "Simon Van de Vyver", title: "PhD student", imgUrl: "" },
+    { name: "Tanja Holstein", title: "PhD student", imgUrl: "" },
+    { name: "Jasper Janin", title: "Master student 2024 - 2025", imgUrl: "" },
     { name: "Peter Dawyndt", title: "P.I.", imgUrl: "https://avatars.githubusercontent.com/u/5736113?v=4" },
     { name: "Lennart Martens", title: "P.I.", imgUrl: "" }
 ];
@@ -178,6 +192,8 @@ const former_members = [
     { name: "Kevin Velghe", title: "Master's student 2015-2016", imgUrl: "" },
     { name: "Aranka Steyaert", title: "Master's student 2016-2017", imgUrl: "" },
     { name: "Niels De Graef", title: "Master's student 2016-2018", imgUrl: "https://avatars.githubusercontent.com/u/1382976?v=4" },
+    { name: "Stijn De Clercq", title: "Master student 2023 - 2024", imgUrl: "" },
+    { name: "Bram Devlaminck", title: "Master student 2023 - 2024", imgUrl: "" },
     { name: "Peter Vandamme", title: "Advisor", imgUrl: "" },
     { name: "Bart Devreese", title: "Advisor", imgUrl: "" },
 ];

--- a/src/components/pages/PublicationsPage.vue
+++ b/src/components/pages/PublicationsPage.vue
@@ -9,6 +9,27 @@
 
         <publication-card
             class="mt-5"
+            title="Unipept in 2024: Expanding Metaproteomics Analysis with Support for Missed Cleavages, Semi-Tryptic and Non-Tryptic Peptides"
+            :authors='["Tibo Vande Moortele", "Bram Devlaminck", "Simon Van de Vyver", "Tim Van Den Bossche", "Lennart Martens", "Peter Dawyndt", "Bart Mesuere", "Pieter Verschaffelt"]'
+            journal="BioRXiv"
+            year="2024"
+            doi="doi.org/10.1101/2024.09.26.615136"
+            google-scholar="https://scholar.google.com/scholar?hl=nl&as_sdt=0%2C5&q=unipept+in+2024&btnG=&oq=unipe"
+            :image="Publication2023Image"
+        >
+            <template #abstract>
+                Unipept, a pioneering software tool in metaproteomics, has significantly advanced the analysis of complex ecosystems by facilitating both taxonomic and functional insights from environmental samples.
+                From the onset, Unipept’s capabilities focused on tryptic peptides, utilizing the predictability and consistency of trypsin digestion to efficiently construct a protein reference database.
+                However, the evolving landscape of proteomics and emerging fields like immunopeptidomics necessitate a more versatile approach that extends beyond the analysis of tryptic peptides.
+                In this article, we present a significant update to the underlying index structure of Unipept, which is now powered by a Sparse Suffix Array index.
+                This advancement enables the analysis of semi-tryptic peptides, peptides with missed cleavages, and non-tryptic peptides such as those encountered in other research fields such as immunopeptidomics (e.g. MHC- and HLA-peptides).
+                This new index benefits all tools in the Unipept ecosystem such as the web application, desktop tool, API and command line interface.
+                A benchmark study highlights significantly improved performance in handling missed cleavages, preserving the same level of accuracy.
+            </template>
+        </publication-card>
+
+        <publication-card
+            class="mt-5"
             title="Unipept Desktop 2.0: Construction of Targeted Reference Protein Databases for Metaproteogenomics Analyses"
             :authors='["Pieter Verschaffelt", "Alessandro Tanca", "Marcello Abbondio", "Tim Van Den Bossche", "Tibo Vande Moortele", "Peter Dawyndt", "Lennart Martens", "Bart Mesuere"]'
             journal="Journal of Proteome Research"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,8 +2,8 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
 const tpaMeta = {
-    publication: "Gurdeep Singh et al. (2019) Journal of Proteome Research",
-    publicationLink: "doi:10.1021/acs.jproteome.8b00716",
+    publication: "Vande Moortele et al. (2024) BioRXiv",
+    publicationLink: "doi.org/10.1101/2024.09.26.615136",
 };
 
 const apidocsMeta = {
@@ -27,8 +27,8 @@ const newsMeta = {
 };
 
 const desktopMeta = {
-    publication: "Verschaffelt et al. (2021) Journal of Proteome Research",
-    publicationLink: "doi.org/10.1021/acs.jproteome.0c00855"
+    publication: "Verschaffelt et al. (2023) Journal of Proteome Research",
+    publicationLink: "doi.org/10.1021/acs.jproteome.3c00091"
 }
 
 const routes = [
@@ -36,8 +36,8 @@ const routes = [
         path: "/",
         component: () => import("@/components/pages/HomePage.vue"),
         meta: {
-            publication: "Gurdeep Singh et al. (2019) Journal of Proteome Research",
-            publicationLink: "doi:10.1021/acs.jproteome.8b00716"
+            publication: "Vande Moortele et al. (2024) BioRXiv",
+            publicationLink: "doi.org/10.1101/2024.09.26.615136"
         }
     },
     {
@@ -55,8 +55,8 @@ const routes = [
         path: "/mpa",
         component: () => import("@/components/pages/features/MetaproteomeAnalysisPage.vue"),
         meta: {
-            publication: "Gurdeep Singh et al. (2019) Journal of Proteome Research",
-            publicationLink: "doi:10.1021/acs.jproteome.8b00716"
+            publication: "Vande Moortele et al. (2024) BioRXiv",
+            publicationLink: "doi.org/10.1101/2024.09.26.615136"
         }
     },
     {


### PR DESCRIPTION
I've done some housekeeping and updated the about page, as well as the page with all publications for the Unipept website. The footer of the web app has also been updated to point to our most recent article (on BioRXiv for now) instead of "Unipept 4.0".