### PR TITLE
Fix/add group button

### DIFF
--- a/src/components/new/project/Project.vue
+++ b/src/components/new/project/Project.vue
@@ -34,7 +34,7 @@
 
         <new-project
             v-if="project.empty"
-            @group:add="addGroup"
+            @group:add="addGroup(`${DEFAULT_NEW_GROUP_NAME} ${project.findFirstAvailableGroupNumber()}`)"
         />
 
         <v-empty-state

--- a/src/store/new/GroupAnalysisStore.ts
+++ b/src/store/new/GroupAnalysisStore.ts
@@ -56,7 +56,7 @@ const useGroupAnalysisStore = defineStore('_groupsampleStore', () => {
      * Returns a number for the default group naming, such that the new default group's name is unique.
      */
     const findFirstAvailableGroupNumber = () => {
-        const existingGroupNames: string[] = _groups.value.map(g => g.name);
+        const existingGroupNames: string[] = [..._groups.value.values()].map(g => g.name);
         let counter = 1;
         while (existingGroupNames.includes(`${DEFAULT_NEW_GROUP_NAME} ${counter}`)) {
             counter += 1;


### PR DESCRIPTION
This resolves issue #1578.

Clicking the "add group" button now creates a unique group name and adds it to the store.