### PR TITLE
Fix "manage group" dialog

### DIFF
--- a/src/components/sample/AddSampleCard.vue
+++ b/src/components/sample/AddSampleCard.vue
@@ -22,41 +22,10 @@
                 no-resize
             />
         </div>
-        <div class="align-self-center">
-            <v-checkbox
-                v-model="sample.config.equate"
-                color="primary"
-                label="Equate I and L"
-                density="compact"
-                hide-details
-            />
-            <v-checkbox
-                v-model="sample.config.filter"
-                color="primary"
-                label="Filter duplicate peptides"
-                density="compact"
-                hide-details
-            />
-            <v-checkbox
-                v-model="sample.config.missed"
-                color="primary"
-                label="Enable missed cleavages"
-                density="compact"
-                hide-details
-                disabled
-            />
-            <!--            <database-select-->
-            <!--                v-model="sample.config.database"-->
-            <!--                class="mt-1"-->
-            <!--                label="Selected database"-->
-            <!--                hide-details-->
-            <!--            />-->
-        </div>
     </div>
 </template>
 
 <script setup lang="ts">
-import DatabaseSelect from "@/components/database/DatabaseSelect.vue";
 import {SampleTableItem} from "@/components/sample/SampleTable.vue";
 
 const props = defineProps<{

--- a/src/components/sample/ManageSampleGroup.vue
+++ b/src/components/sample/ManageSampleGroup.vue
@@ -194,6 +194,16 @@ const removeGroup = () => {
 };
 
 const addSamples = (newSamples: SampleTableItem[]) => {
+    const lastSampleIndex = samples.value.length - 1;
+    if (lastSampleIndex >= 0) {
+        newSamples.forEach(s => s.config = {
+            equate: samples.value[lastSampleIndex].config.equate,
+            filter: samples.value[lastSampleIndex].config.filter,
+            missed: samples.value[lastSampleIndex].config.missed,
+            database: samples.value[lastSampleIndex].config.database
+        });
+    }
+
     samples.value = [...samples.value!, ...newSamples ];
     addingSample.value = false;
 };
@@ -206,6 +216,7 @@ watch(dialogOpen, () => {
         // If the dialog is closed, confirm the changes
         confirmChanges();
     }
+    addingSample.value = false;
 });
 </script>
 

--- a/src/components/sample/ManageSampleGroup.vue
+++ b/src/components/sample/ManageSampleGroup.vue
@@ -75,6 +75,7 @@
                         variant="text"
                         text="Undo changes"
                         prepend-icon="mdi-undo"
+                        :disabled="!canUndo"
                         @click="undoChangesDialogOpen = true"
                     />
 
@@ -139,6 +140,15 @@ const isValid = computed(() => {
     const allUnique = samples.value.every(s => samples.value.filter(s2 => s2.name === s.name).length === 1);
     return noneEmpty && allUnique;
 });
+
+const canUndo = computed(() =>
+    groupName.value !== group.name
+    || group.analyses.some(s => !samples.value.find(s2 => s2.id === s.id))
+    || samples.value.some(s => {
+        const originalAnalysis = group.getAnalysis(s.id);
+        return !originalAnalysis || (originalAnalysis && isDirty(originalAnalysis, s));
+    })
+);
 
 const isUnique = (item: SampleTableItem) => {
     return samples.value!.filter(s => s.id !== item?.id && s.name === item.name).length === 0


### PR DESCRIPTION
Fixes the following problems when managing a group's samples:
- Cancel button should only be active when at least one change has been made
- Use search settings from previously added sample when creating a new sample
