### PR TITLE
Fix selection in heatmap

### DIFF
--- a/src/components/results/taxonomic/heatmap/DataSourceSelectTable.vue
+++ b/src/components/results/taxonomic/heatmap/DataSourceSelectTable.vue
@@ -30,7 +30,6 @@
             v-model="selected"
             :headers="headers"
             :items="items"
-            :value-comparator="Object.is"
             :search="selectedCategory"
             :custom-filter="categoryFilter"
             :items-per-page="5"


### PR DESCRIPTION
Fixes issue #1582 
- When using the select box in the header. All currently visible rows should be highlighted and selected