### PR TITLE
Rework analysis overview page

### DIFF
--- a/src/components/analysis/multi/AnalysisSummary.vue
+++ b/src/components/analysis/multi/AnalysisSummary.vue
@@ -60,7 +60,6 @@
 
                     <div class="mt-1">
                         <v-icon
-                            v-bind="tooltip"
                             class="ms-1"
                             :icon="analysis.config.missed ? 'mdi-check-circle' : 'mdi-close-circle'"
                             :color="analysis.config.missed ? 'success' : 'error'"

--- a/src/components/analysis/multi/AnalysisSummary.vue
+++ b/src/components/analysis/multi/AnalysisSummary.vue
@@ -1,10 +1,10 @@
 <template>
     <v-card flat>
         <v-card-title>
-            <span class="text-h4">{{ analysis.name }} ({{ groupName }})</span>
+            <span class="text-h4">{{ analysis.name }} ({{ group.name }})</span>
         </v-card-title>
         <v-card-text>
-            <v-row class="mt-n6">
+            <v-row class="mt-n6 d-flex align-center">
                 <v-col cols="8">
                     <h2 class="pb-2">
                         Analysis summary
@@ -38,7 +38,6 @@
                 <v-col cols="4">
                     <div class="mt-1">
                         <v-icon
-                            v-bind="tooltip"
                             class="ms-1"
                             :icon="analysis.config.equate ? 'mdi-check-circle' : 'mdi-close-circle'"
                             :color="analysis.config.equate ? 'success' : 'error'"
@@ -50,7 +49,6 @@
 
                     <div class="mt-1">
                         <v-icon
-                            v-bind="tooltip"
                             class="ms-1"
                             :icon="analysis.config.filter ? 'mdi-check-circle' : 'mdi-close-circle'"
                             :color="analysis.config.filter ? 'success' : 'error'"
@@ -87,16 +85,26 @@
                         </v-tooltip>
                     </div>
 
-                    <div class="mt-5">
+                    <div class="mt-1">
                         <v-icon
-                            v-bind="tooltip"
                             class="ms-1"
                             icon="mdi-database"
-                            color="primary"
+                            color="grey"
                         />
                         <span>
                             Selected database: {{ analysis.config.database }}
                         </span>
+                    </div>
+
+                    <div class="mt-5">
+                        <v-icon
+                            class="ms-1"
+                            icon="mdi-pencil"
+                            color="primary"
+                        />
+                        <a @click="editAnalysis">
+                            Edit search parameters
+                        </a>
                     </div>
                 </v-col>
             </v-row>
@@ -133,6 +141,8 @@ import usePeptideExport from "@/composables/usePeptideExport";
 import MissingPeptidesDialog from "@/components/analysis/multi/MissingPeptidesDialog.vue";
 import DatabaseSelect from "@/components/database/DatabaseSelect.vue";
 import useMetaData from "@/composables/communication/unipept/useMetaData";
+import ManageSampleGroup from "@/components/sample/ManageSampleGroup.vue";
+import {MultiAnalysisStore} from "@/store/new/MultiAnalysisStore";
 
 const { getNcbiDefinition } = useOntologyStore();
 const { displayPercentage } = usePercentage();
@@ -142,7 +152,11 @@ const { databaseVersion: latest, process } = useMetaData();
 
 const { analysis } = defineProps<{
     analysis: SingleAnalysisStore
-    groupName: string
+    group: MultiAnalysisStore
+}>();
+
+const emits = defineEmits<{
+    (e: 'edit'): void;
 }>();
 
 const showMissingPeptides = ref(false);
@@ -179,6 +193,10 @@ const download = async (callback: () => void): Promise<void> => {
 
 const restartAnalysis = async () => {
     await analysis.analyse();
+}
+
+const editAnalysis = () => {
+    emits('edit');
 }
 
 onMounted(process);

--- a/src/components/analysis/multi/AnalysisSummary.vue
+++ b/src/components/analysis/multi/AnalysisSummary.vue
@@ -21,6 +21,18 @@
                                 {{ analysis.peptideTrust.missedPeptides.length }} peptides
                             </a> ({{ displayPercentage(analysis.peptideTrust.missedPeptides.length / analysis.peptideTrust.searchedPeptides) }}) could not be found.
                         </h1>
+
+                        <h3 class="font-weight-bold mt-3">
+                            Last analysed on {{ analysis.lastAnalysedString }}
+                        </h3>
+
+                        <h1 v-if="latest === analysis.databaseVersion" class="text-subtitle-1">
+                            Analysis is up-to-date with the latest UniProt release ({{ analysis.databaseVersion }}).
+                        </h1>
+
+                        <h1 v-else class="text-subtitle-1">
+                            Analysis is outdated. The latest UniProt release is {{ latest }}. Click <a @click="restartAnalysis">here</a> to restart the analysis.
+                        </h1>
                     </template>
                 </v-col>
                 <v-col cols="4">
@@ -112,7 +124,7 @@
 <script setup lang="ts">
 import AnalysisSummaryTable from "@/components/analysis/multi/AnalysisSummaryTable.vue";
 import {SingleAnalysisStore} from "@/store/new/SingleAnalysisStore";
-import {computed, ref} from "vue";
+import {computed, onMounted, ref} from "vue";
 import usePercentage from "@/composables/usePercentage";
 import useOntologyStore from "@/store/new/OntologyStore";
 import AnalysisSummaryExport from "@/components/analysis/multi/AnalysisSummaryExport.vue";
@@ -120,11 +132,13 @@ import useCsvDownload from "@/composables/useCsvDownload";
 import usePeptideExport from "@/composables/usePeptideExport";
 import MissingPeptidesDialog from "@/components/analysis/multi/MissingPeptidesDialog.vue";
 import DatabaseSelect from "@/components/database/DatabaseSelect.vue";
+import useMetaData from "@/composables/communication/unipept/useMetaData";
 
 const { getNcbiDefinition } = useOntologyStore();
 const { displayPercentage } = usePercentage();
 const { generateExport } = usePeptideExport();
 const { download: downloadCsv } = useCsvDownload();
+const { databaseVersion: latest, process } = useMetaData();
 
 const { analysis } = defineProps<{
     analysis: SingleAnalysisStore
@@ -162,6 +176,12 @@ const download = async (callback: () => void): Promise<void> => {
     await downloadCsv(peptideExportContent, `unipept_${analysis.name.replaceAll(" ", "_")}_mpa.${exportExtension}`, exportDelimiter);
     callback();
 }
+
+const restartAnalysis = async () => {
+    await analysis.analyse();
+}
+
+onMounted(process);
 </script>
 
 <style scoped>

--- a/src/components/analysis/multi/AnalysisSummary.vue
+++ b/src/components/analysis/multi/AnalysisSummary.vue
@@ -24,31 +24,40 @@
                     </template>
                 </v-col>
                 <v-col cols="4">
-                    <v-checkbox
-                        :model-value="analysis.config.equate"
-                        color="primary"
-                        label="Equate I and L"
-                        density="compact"
-                        hide-details
-                        readonly
-                    />
-                    <v-checkbox
-                        :model-value="analysis.config.filter"
-                        color="primary"
-                        label="Filter duplicate peptides"
-                        density="compact"
-                        hide-details
-                        readonly
-                    />
-                    <div class="d-flex align-center">
-                        <v-checkbox
-                            :model-value="analysis.config.missed"
-                            color="primary"
-                            density="compact"
-                            hide-details
-                            label="Advanced missed cleavages"
-                            disabled
+                    <div class="mt-1">
+                        <v-icon
+                            v-bind="tooltip"
+                            class="ms-1"
+                            :icon="analysis.config.equate ? 'mdi-check-circle' : 'mdi-close-circle'"
+                            :color="analysis.config.equate ? 'success' : 'error'"
                         />
+                        <span>
+                            Equate I and L
+                        </span>
+                    </div>
+
+                    <div class="mt-1">
+                        <v-icon
+                            v-bind="tooltip"
+                            class="ms-1"
+                            :icon="analysis.config.filter ? 'mdi-check-circle' : 'mdi-close-circle'"
+                            :color="analysis.config.filter ? 'success' : 'error'"
+                        />
+                        <span>
+                            Filter duplicate peptides
+                        </span>
+                    </div>
+
+                    <div class="mt-1">
+                        <v-icon
+                            v-bind="tooltip"
+                            class="ms-1"
+                            :icon="analysis.config.missed ? 'mdi-check-circle' : 'mdi-close-circle'"
+                            :color="analysis.config.missed ? 'success' : 'error'"
+                        />
+                        <span>
+                            Advanced missed cleavages
+                        </span>
                         <v-tooltip width="30%">
                             <template #activator="{ props: tooltip }">
                                 <v-icon
@@ -66,12 +75,17 @@
                         </v-tooltip>
                     </div>
 
-                    <database-select
-                        :model-value="analysis.config.database"
-                        class="mt-1"
-                        label="Selected database"
-                        readonly
-                    />
+                    <div class="mt-5">
+                        <v-icon
+                            v-bind="tooltip"
+                            class="ms-1"
+                            icon="mdi-database"
+                            color="primary"
+                        />
+                        <span>
+                            Selected database: {{ analysis.config.database }}
+                        </span>
+                    </div>
                 </v-col>
             </v-row>
             <v-row>

--- a/src/components/analysis/multi/AnalysisSummaryTable.vue
+++ b/src/components/analysis/multi/AnalysisSummaryTable.vue
@@ -32,6 +32,7 @@
                         v-bind="props"
                         size="30"
                         :color="item.faCounts.go > 0 ? 'amber' : 'amber-lighten-4'"
+                        class="me-1"
                     >
                         <span
                             :class="[ item.faCounts.go > 0 ? 'dark--text' : 'gray--text', 'headline']"
@@ -60,6 +61,7 @@
                         v-bind="props"
                         size="30"
                         :color="item.faCounts.ec > 0 ? 'indigo' : 'indigo-lighten-4'"
+                        class="me-1"
                     >
                         <span
                             class="text-white"

--- a/src/components/project/Project.vue
+++ b/src/components/project/Project.vue
@@ -61,6 +61,7 @@
                 </div>
 
                 <analysis-summary
+                    v-if="selectedGroup"
                     :analysis="selectedAnalysis"
                     :group="selectedGroup"
                     @edit="manageSamplesDialogOpen = true"
@@ -77,6 +78,7 @@
                 />
 
                 <manage-sample-group
+                    v-if="selectedGroup"
                     v-model="manageSamplesDialogOpen"
                     :group="selectedGroup"
                     @sample:add="addSample"
@@ -102,7 +104,7 @@ import {SingleAnalysisStore} from "@/store/new/SingleAnalysisStore";
 import {DEFAULT_NEW_GROUP_NAME, GroupAnalysisStore} from "@/store/new/GroupAnalysisStore";
 import NewProject from "@/components/project/NewProject.vue";
 import {AnalysisStatus} from "@/store/new/AnalysisStatus";
-import MultiAnalysisStore from "@/store/new/MultiAnalysisStore";
+import {MultiAnalysisStore} from "@/store/new/MultiAnalysisStore";
 import ManageSampleGroup from "@/components/sample/ManageSampleGroup.vue";
 
 const { project } = defineProps<{

--- a/src/components/project/Project.vue
+++ b/src/components/project/Project.vue
@@ -62,7 +62,8 @@
 
                 <analysis-summary
                     :analysis="selectedAnalysis"
-                    :group-name="selectedGroupName!"
+                    :group="selectedGroup"
+                    @edit="manageSamplesDialogOpen = true"
                 />
 
                 <taxonomic-results
@@ -73,6 +74,16 @@
                 <mpa-functional-results
                     class="mt-5"
                     :analysis="selectedAnalysis"
+                />
+
+                <manage-sample-group
+                    v-model="manageSamplesDialogOpen"
+                    :group="selectedGroup"
+                    @sample:add="addSample"
+                    @sample:update="updateSample"
+                    @sample:remove="removeSample"
+                    @group:update="updateGroup"
+                    @group:remove="removeGroup"
                 />
             </div>
         </div>
@@ -91,6 +102,8 @@ import {SingleAnalysisStore} from "@/store/new/SingleAnalysisStore";
 import {DEFAULT_NEW_GROUP_NAME, GroupAnalysisStore} from "@/store/new/GroupAnalysisStore";
 import NewProject from "@/components/project/NewProject.vue";
 import {AnalysisStatus} from "@/store/new/AnalysisStatus";
+import MultiAnalysisStore from "@/store/new/MultiAnalysisStore";
+import ManageSampleGroup from "@/components/sample/ManageSampleGroup.vue";
 
 const { project } = defineProps<{
     project: GroupAnalysisStore;
@@ -105,8 +118,9 @@ const emits = defineEmits<{
     (e: 'group:remove', groupId: string):  void;
 }>();
 
-const selectedGroupName = ref<string>();
+const manageSamplesDialogOpen = ref(false);
 const selectedAnalyses: Ref = ref<SingleAnalysisStore[]>([]);
+const selectedGroup = ref<MultiAnalysisStore | undefined>();
 
 const selectedAnalysis: ComputedRef = computed(() => selectedAnalyses.value?.[0]);
 
@@ -150,8 +164,8 @@ const selectAnalysis = (groupId: string | undefined, analysisId: string | undefi
     if (groupId && analysisId) {
         const analysis = project.getGroup(groupId)?.getAnalysis(analysisId);
         selectedAnalyses.value = analysis ? [ analysis ] : [];
+        selectedGroup.value = project.getGroup(groupId);
     }
-    selectedGroupName.value = groupId ? project.getGroup(groupId)?.name : undefined;
 }
 
 const isSafari = ref(false);

--- a/src/composables/communication/unipept/useMetaData.ts
+++ b/src/composables/communication/unipept/useMetaData.ts
@@ -1,0 +1,17 @@
+import {ref} from "vue";
+
+export default function useMetaData(
+    baseUrl = "https://api.unipept.ugent.be",
+) {
+    const databaseVersion = ref<string>("");
+
+    const process = async () => {
+        const response = await fetch(`${baseUrl}/private_api/metadata`).then(r => r.json());
+        databaseVersion.value = response.db_version;
+    }
+
+    return {
+        databaseVersion,
+        process
+    }
+}

--- a/src/store/new/SingleAnalysisStore.ts
+++ b/src/store/new/SingleAnalysisStore.ts
@@ -13,6 +13,7 @@ import usePeptonizerStore from "@/store/new/PeptonizerAnalysisStore";
 import {AnalysisStatus} from "@/store/new/AnalysisStatus";
 import {AnalysisConfig} from "@/store/new/AnalysisConfig";
 import useCustomFilterStore from "@/store/new/CustomFilterStore";
+import useMetaData from "@/composables/communication/unipept/useMetaData";
 
 
 const useSingleAnalysisStore = (
@@ -25,6 +26,7 @@ const useSingleAnalysisStore = (
 ) => defineStore(`singleSampleStore/${_id}`, () => {
     const ontologyStore = useOntologyStore();
     const customFilterStore = useCustomFilterStore();
+    const peptonizerStore = usePeptonizerStore(_id);
 
     // ===============================================================
     // ======================== REFERENCES ===========================
@@ -32,6 +34,7 @@ const useSingleAnalysisStore = (
 
     const status = ref<AnalysisStatus>(AnalysisStatus.Pending);
     const filteringStatus = ref<AnalysisStatus>(AnalysisStatus.Finished);
+    const lastAnalysed = ref<Date | undefined>(undefined);
 
     const id = ref<string>(_id);
     const name = ref<string>(_name);
@@ -48,6 +51,7 @@ const useSingleAnalysisStore = (
 
     const { peptideData: peptideToData, process: processPept2Filtered } = usePept2filtered();
 
+    const { databaseVersion, process: processMetadata } = useMetaData();
     const { countTable: peptidesTable, process: processPeptides } = usePeptideProcessor();
     const { countTable: filteredPeptidesTable, process: processFilteredPeptides } = usePeptideProcessor();
     const { trust: peptideTrust, process: processPeptideTrust } = usePeptideTrustProcessor();
@@ -56,7 +60,6 @@ const useSingleAnalysisStore = (
     const { countTable: iprTable, trust: iprTrust, iprToPeptides, process: processInterpro } = useInterproProcessor();
     const { countTable: lcaTable, lcaToPeptides, peptideToLca, process: processLca } = useTaxonomicProcessor();
     const { root: ncbiTree, nodes: ncbiTreeNodes, process: processNcbiTree } = useNcbiTreeProcessor();
-    const peptonizerStore = usePeptonizerStore(_id);
 
     // ===============================================================
     // ========================= COMPUTED ============================
@@ -67,6 +70,20 @@ const useSingleAnalysisStore = (
     );
 
     const filteredOrganism = computed(() => ncbiTreeNodes.value.get(taxonomicFilter.value));
+
+    const lastAnalysedString = computed(() => {
+        if (!lastAnalysed.value) return "";
+
+        const formatter = new Intl.DateTimeFormat(undefined, {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+            hour: "numeric",
+            minute: "numeric"
+        })
+
+        return formatter.format(lastAnalysed.value);
+    });
 
     // ===============================================================
     // ========================== METHODS ============================
@@ -80,6 +97,9 @@ const useSingleAnalysisStore = (
         const filter = customFilterStore.getFilter(config.value.database);
         await processPept2Filtered([...peptidesTable.value!.keys()], config.value.equate, filter);
         processPeptideTrust(peptidesTable!.value!, peptideToData.value!);
+
+        await processMetadata();
+        lastAnalysed.value = new Date();
 
         await processLca(peptidesTable.value!, peptideToData.value!);
         await processEc(peptidesTable!.value!, peptideToData.value!, functionalFilter.value!);
@@ -168,6 +188,8 @@ const useSingleAnalysisStore = (
         functionalFilter,
         status,
         filteringStatus,
+        databaseVersion,
+        lastAnalysedString,
 
         peptideToData,
         peptidesTable,


### PR DESCRIPTION
Do some reworking of the analysis overview page
- Create a textual, readonly, non-clickable component for the search settings.
- List the UniProt version and show the "last analysed on" timestamp.
- Provide a quick link edit option. This can link to the same edit group dialog.
- Add margins to the annotations in the peptide table.

<img width="1213" alt="Screenshot 2025-03-13 at 14 11 28" src="https://github.com/user-attachments/assets/01ff21b6-933f-4ec6-b761-9798f35bc3cd" />
