### PR TITLE
Disable descendants from taxa that are already selected in TaxaBrowser

### DIFF
--- a/src/components/browsers/DatabaseSummary.vue
+++ b/src/components/browsers/DatabaseSummary.vue
@@ -32,8 +32,8 @@
                                 v-for="item in selectedItems"
                                 :key="itemDisplayName(item)"
                                 :class="`bg-${chipBackgroundColor(item)}`"
+                                :variant="chipVariant(item)"
                                 closable
-                                variant="flat"
                                 @click:close="handleRemoveItem(item)"
                             >
                                 {{ itemDisplayName(item) }}
@@ -111,6 +111,7 @@ const props = defineProps<{
     description: string;
     emptyPlaceholder: string;
     chipBackgroundColor: (item: T) => string;
+    chipVariant: (item: T) => string;
     itemDisplayName: (item: T) => string;
     invalidItems: string[];
     computeProteinCount: (items: T[]) => Promise<number>;

--- a/src/components/browsers/DatabaseSummary.vue
+++ b/src/components/browsers/DatabaseSummary.vue
@@ -111,7 +111,7 @@ const props = defineProps<{
     description: string;
     emptyPlaceholder: string;
     chipBackgroundColor: (item: T) => string;
-    chipVariant: (item: T) => string;
+    chipVariant: (item: T) => 'flat' | 'plain';
     itemDisplayName: (item: T) => string;
     invalidItems: string[];
     computeProteinCount: (items: T[]) => Promise<number>;

--- a/src/components/browsers/DatabaseSummary.vue
+++ b/src/components/browsers/DatabaseSummary.vue
@@ -180,7 +180,7 @@ const countTaxa = async () => {
 watch(selectedItems, () => {
     countProteins();
     countTaxa();
-});
+}, { deep: true });
 
 onMounted(() => {
     countProteins();

--- a/src/components/browsers/TaxaBrowser.vue
+++ b/src/components/browsers/TaxaBrowser.vue
@@ -210,7 +210,7 @@ const getRankColor = (taxon: NcbiTaxon): string => {
     return rankColors[idx % rankColors.length];
 }
 
-const getRankState = (taxon: NcbiTaxon): string => {
+const getRankState = (taxon: NcbiTaxon): 'flat' | 'plain' => {
     if (ancestorSelected(taxon)) {
         return "plain";
     }

--- a/src/components/browsers/TaxaBrowser.vue
+++ b/src/components/browsers/TaxaBrowser.vue
@@ -9,6 +9,7 @@
             :compute-protein-count="computeProteinCount"
             :compute-taxon-count="async (items) => 0"
             :chip-background-color="getRankColor"
+            :chip-variant="getRankState"
             :item-display-name="(taxon: NcbiTaxon) => taxon.name"
             @upload-file="processUploadedTaxa"
             class="mb-2"
@@ -194,7 +195,7 @@ const {
 const {ontology: ncbiOntology, update: updateNcbiOntology} = useNcbiOntology();
 
 const ancestorSelected = (taxon: NcbiTaxon) => {
-    return selectedItems.value.some((selected: NcbiTaxon) => taxon.lineage.includes(selected.id));
+    return selectedItems.value.some((selected: NcbiTaxon) => taxon.id != selected.id && taxon.lineage.includes(selected.id));
 };
 
 // Start of logic that handles presentation and UI of the component
@@ -208,6 +209,12 @@ const getRankColor = (taxon: NcbiTaxon): string => {
     return rankColors[idx % rankColors.length];
 }
 
+const getRankState = (taxon: NcbiTaxon): string => {
+    if (ancestorSelected(taxon)) {
+        return "plain";
+    }
+    return "flat";
+}
 
 // Start of logic for processing the uploaded taxon file
 const processUploadedTaxa = async (file: File, callback: () => void) => {

--- a/src/components/browsers/TaxaBrowser.vue
+++ b/src/components/browsers/TaxaBrowser.vue
@@ -64,6 +64,25 @@
                             Remove
                         </v-btn>
 
+                        <v-tooltip
+                            v-else-if="ancestorSelected(item)"
+                            text="This taxon is already included because of an ancestor"
+                        >
+                            <template #activator="{ props }">
+                                <div v-bind="props" class="d-inline-block">
+                                    <v-btn
+                                        color="primary"
+                                        density="compact"
+                                        variant="text"
+                                        prepend-icon="mdi-plus"
+                                        disabled
+                                    >
+                                        Select
+                                    </v-btn>
+                                </div>
+                            </template>
+                        </v-tooltip>
+
                         <v-btn
                             v-else
                             color="primary"
@@ -174,6 +193,9 @@ const {
 
 const {ontology: ncbiOntology, update: updateNcbiOntology} = useNcbiOntology();
 
+const ancestorSelected = (taxon: NcbiTaxon) => {
+    return selectedItems.value.some((selected: NcbiTaxon) => taxon.lineage.includes(selected.id));
+};
 
 // Start of logic that handles presentation and UI of the component
 /**

--- a/src/logic/communicators/unipept/taxonomic/TaxonomyResponse.ts
+++ b/src/logic/communicators/unipept/taxonomic/TaxonomyResponse.ts
@@ -1,0 +1,8 @@
+import {NcbiId, NcbiRank} from "@/logic/ontology/taxonomic/Ncbi";
+
+export default interface TaxonomyResponse {
+    taxon_id: NcbiId,
+    taxon_name: string,
+    taxon_rank: NcbiRank,
+    descendants: NcbiId[]
+}

--- a/src/logic/communicators/unipept/taxonomic/TaxonomyResponseCommunicator.ts
+++ b/src/logic/communicators/unipept/taxonomic/TaxonomyResponseCommunicator.ts
@@ -1,0 +1,47 @@
+import TaxonomyResponse from "@/logic/communicators/unipept/taxonomic/TaxonomyResponse";
+import {NcbiId} from "@/logic/ontology/taxonomic/Ncbi";
+import NetworkUtils from "@/logic/communicators/NetworkUtils";
+
+export default class TaxonomyResponseCommunicator {
+    public static readonly NCBI_TAXONOMY_ENDPOINT: string = "/api/v2/taxonomy";
+
+    private static inProgress: Promise<TaxonomyResponse[]> | undefined;
+
+    constructor(
+        private readonly apiBaseUrl: string,
+        private readonly batchSize: number
+    ) {}
+
+    public async getResponses(
+        codes: NcbiId[]
+    ): Promise<TaxonomyResponse[]> {
+        while (TaxonomyResponseCommunicator.inProgress) {
+            await TaxonomyResponseCommunicator.inProgress;
+        }
+
+        TaxonomyResponseCommunicator.inProgress = this.doProcess(codes);
+        let result: TaxonomyResponse[];
+
+        try {
+            result = await TaxonomyResponseCommunicator.inProgress;
+        } finally {
+            TaxonomyResponseCommunicator.inProgress = undefined;
+        }
+
+        return result;
+    }
+
+    private async doProcess(
+        codes: NcbiId[]
+    ): Promise<TaxonomyResponse[]> {
+        const requestBody = JSON.stringify({
+            input: codes,
+            descendants: true
+        });
+
+        return await NetworkUtils.postJSON(
+            this.apiBaseUrl + TaxonomyResponseCommunicator.NCBI_TAXONOMY_ENDPOINT,
+            requestBody
+        );
+    }
+}


### PR DESCRIPTION
This PR:
- fixes #1614: disable descendants when an ancestor is already selected. Visualize this in the database summary, when a descendant is selected before its ancestor.
- Compute the total amount of taxa in the database