### PR TITLE
Show correct icon when peptonizer scores are provided and add a toolt…

### DIFF
--- a/src/components/filesystem/FilesystemGroup.vue
+++ b/src/components/filesystem/FilesystemGroup.vue
@@ -46,8 +46,24 @@
             :title="analysis.name"
             color="primary"
             density="compact"
-            :prepend-icon="analysis.intensities ? 'unipept:file-lightning-outline' : 'mdi-file-document-outline'"
         >
+            <template #prepend>
+                <v-tooltip
+                    v-if="analysis.intensities"
+                    text="Custom intensity scores for Peptonizer provided">
+                    <template #activator="{ props }">
+                        <v-icon
+                            v-bind="props"
+                            icon="unipept:file-lightning-outline"
+                        />
+                    </template>
+                </v-tooltip>
+
+                <v-icon
+                    v-else
+                    icon="mdi-file-document-outline"
+                />
+            </template>
             <template #append>
                 <v-icon
                     v-if="analysis.status === AnalysisStatus.Pending"

--- a/src/components/sample/AddSampleStepper.vue
+++ b/src/components/sample/AddSampleStepper.vue
@@ -280,7 +280,7 @@ const sample = ref<SampleTableItem>({
         missed: true,
         database: "UniProtKB"
     },
-    intensities: new Map<string, number>()
+    intensities: undefined
 });
 
 const currentStepTitle = computed(() => {


### PR DESCRIPTION
Only show the peptonizer icon in the filesystem when valid scores are provided.
We also added a tooltip to indicate the sample has valid scores