### PR TITLE
Fix the sorting by UniProt ID in protein browser

### DIFF
--- a/src/components/browsers/ProteinBrowser.vue
+++ b/src/components/browsers/ProteinBrowser.vue
@@ -187,7 +187,7 @@ const loadProteins = async (params: LoadItemsParams) => {
         params,
         updateProteinOntology,
         proteinOntology,
-        (start: number, end: number, filter?: string, sortByColumn?: string, sortDesc?: boolean) => proteinCommunicator.getProteinRange(start, end, filter, sortByColumn as any, sortDesc),
+        (start: number, end: number, filter?: string, sortByColumn?: string, sortDesc?: boolean) => proteinCommunicator.getProteinRange(start, end, filter, sortByColumn === "id" ? "uniprot_accession_number" : sortByColumn as any, sortDesc),
         (filter) => proteinCommunicator.getProteinCount(filter)
     );
 }

--- a/src/logic/communicators/unipept/protein/ProteinResponseCommunicator.ts
+++ b/src/logic/communicators/unipept/protein/ProteinResponseCommunicator.ts
@@ -78,7 +78,7 @@ export default class ProteinResponseCommunicator {
         start: number,
         end: number,
         filter = "",
-        sortBy: "uniprot_accession_id" | "name" | "db_type" | "taxon_id" = "uniprot_accession_id",
+        sortBy: "uniprot_accession_number" | "name" | "db_type" | "taxon_id" = "uniprot_accession_number",
         sortDescending = false
     ): Promise<string[]> {
         const requestBody = JSON.stringify({


### PR DESCRIPTION
This PR provides a fix for #1631. The default sort key has been changed from "id" to "uniprot_accession_number".