### PR TITLE
Fix protein browser sometimes overrides search results

### DIFF
--- a/src/components/browsers/ProteinBrowser.vue
+++ b/src/components/browsers/ProteinBrowser.vue
@@ -178,7 +178,7 @@ const {
     clearSearch
 } = useBrowserLoader<string, Protein>();
 
-const debouncedFilterValue = refDebounced(filterValue, 300);
+const debouncedFilterValue = refDebounced(filterValue, 600);
 
 const proteinCommunicator = new ProteinResponseCommunicator(DEFAULT_API_BASE_URL, DEFAULT_ONTOLOGY_BATCH_SIZE);
 

--- a/src/components/browsers/ReferenceProteomeBrowser.vue
+++ b/src/components/browsers/ReferenceProteomeBrowser.vue
@@ -144,7 +144,7 @@ const {
     clearSearch
 } = useBrowserLoader<string, ReferenceProteome>();
 
-const debouncedFilterValue = refDebounced(filterValue, 300);
+const debouncedFilterValue = refDebounced(filterValue, 600);
 
 const proteomeCommunicator = new ProteomeCommunicator(DEFAULT_API_BASE_URL, DEFAULT_ONTOLOGY_BATCH_SIZE);
 

--- a/src/components/browsers/TaxaBrowser.vue
+++ b/src/components/browsers/TaxaBrowser.vue
@@ -270,7 +270,7 @@ const {
     clearSearch
 } = useBrowserLoader<number, NcbiTaxon>();
 
-const debouncedFilterValue = refDebounced(filterValue, 300);
+const debouncedFilterValue = refDebounced(filterValue, 600);
 
 const ncbiCommunicator = new NcbiResponseCommunicator(DEFAULT_API_BASE_URL, DEFAULT_ONTOLOGY_BATCH_SIZE);
 const taxonomyCommunicator = new TaxonomyResponseCommunicator(DEFAULT_API_BASE_URL, DEFAULT_ONTOLOGY_BATCH_SIZE);


### PR DESCRIPTION
This PR provides a fix for issue #1632. I've wrapped the part of the `ProteinBrowser` that performs the updates with the `performIfLast` composable.