### PR TITLE
Deep clone samples instead of shallow copies

### DIFF
--- a/src/components/sample/SampleTable.vue
+++ b/src/components/sample/SampleTable.vue
@@ -178,9 +178,11 @@ const duplicateSample = (index: number) => {
     }
 
     const newSample = {
-        ...sample,
         id: uuidv4(),
-        name: `${sample.name} - copy ${counter}`
+        name: `${sample.name} - copy ${counter}`,
+        rawPeptides: `${sample.rawPeptides}`,
+        intensities: sample.intensities ? new Map(sample.intensities) : undefined,
+        config: { ...sample.config }
     };
     samples.value = [ ...samples.value, newSample ];
 }


### PR DESCRIPTION
This fixes issue #1646 where updating a duplicated sample also changed the original sample