### PR TITLE
Update documentation (equateIL is enabled by default)

### DIFF
--- a/src/components/pages/documentation/apidocs/APIPept2EcPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2EcPage.vue
@@ -182,7 +182,7 @@
                                 class="mt-3"
                                 style="font-size: 85%;"
                             >
-                                Value: Must be <inline-code>true</inline-code> or <inline-code>false</inline-code> (default)
+                                Value: Must be <inline-code>true</inline-code> (default) or <inline-code>false</inline-code>
                             </div>
                         </td>
                     </tr>

--- a/src/components/pages/documentation/apidocs/APIPept2FunctPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2FunctPage.vue
@@ -218,7 +218,7 @@
                                 class="mt-3"
                                 style="font-size: 85%;"
                             >
-                                Value: Must be <inline-code>true</inline-code> or <inline-code>false</inline-code> (default)
+                                Value: Must be <inline-code>true</inline-code> (default) or <inline-code>false</inline-code>
                             </div>
                         </td>
                     </tr>

--- a/src/components/pages/documentation/apidocs/APIPept2GoPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2GoPage.vue
@@ -190,7 +190,7 @@
                                 class="mt-3"
                                 style="font-size: 85%;"
                             >
-                                Value: Must be <inline-code>true</inline-code> or <inline-code>false</inline-code> (default)
+                                Value: Must be <inline-code>true</inline-code> (default) or <inline-code>false</inline-code>
                             </div>
                         </td>
                     </tr>

--- a/src/components/pages/documentation/apidocs/APIPept2InterproPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2InterproPage.vue
@@ -187,7 +187,7 @@
                                 class="mt-3"
                                 style="font-size: 85%;"
                             >
-                                Value: Must be <inline-code>true</inline-code> or <inline-code>false</inline-code> (default)
+                                Value: Must be <inline-code>true</inline-code> (default) or <inline-code>false</inline-code>
                             </div>
                         </td>
                     </tr>

--- a/src/components/pages/documentation/apidocs/APIPept2LcaPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2LcaPage.vue
@@ -249,7 +249,7 @@
                                 class="mt-3"
                                 style="font-size: 85%;"
                             >
-                                Value: Must be <inline-code>true</inline-code> or <inline-code>false</inline-code> (default)
+                                Value: Must be <inline-code>true</inline-code> (default) or <inline-code>false</inline-code>
                             </div>
                         </td>
                     </tr>

--- a/src/components/pages/documentation/apidocs/APIPept2ProtPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2ProtPage.vue
@@ -193,7 +193,7 @@
                                 class="mt-3"
                                 style="font-size: 85%;"
                             >
-                                Value: Must be <inline-code>true</inline-code> or <inline-code>false</inline-code> (default)
+                                Value: Must be <inline-code>true</inline-code> (default) or <inline-code>false</inline-code>
                             </div>
                         </td>
                     </tr>

--- a/src/components/pages/documentation/apidocs/APIPept2TaxaPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2TaxaPage.vue
@@ -267,7 +267,7 @@
                                 class="mt-3"
                                 style="font-size: 85%;"
                             >
-                                Value: Must be <inline-code>true</inline-code> or <inline-code>false</inline-code> (default)
+                                Value: Must be <inline-code>true</inline-code> (default) or <inline-code>false</inline-code>
                             </div>
                         </td>
                     </tr>

--- a/src/components/pages/documentation/apidocs/APIPeptInfoPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPeptInfoPage.vue
@@ -320,7 +320,7 @@
                                 class="mt-3"
                                 style="font-size: 85%;"
                             >
-                                Value: Must be <inline-code>true</inline-code> or <inline-code>false</inline-code> (default)
+                                Value: Must be <inline-code>true</inline-code> (default) or <inline-code>false</inline-code>
                             </div>
                         </td>
                     </tr>

--- a/src/components/pages/documentation/apidocs/APIProtInfoPage.vue
+++ b/src/components/pages/documentation/apidocs/APIProtInfoPage.vue
@@ -285,7 +285,7 @@
                                 class="mt-3"
                                 style="font-size: 85%;"
                             >
-                                Value: Must be <inline-code>true</inline-code> or <inline-code>false</inline-code> (default)
+                                Value: Must be <inline-code>true</inline-code> (default) or <inline-code>false</inline-code>
                             </div>
                         </td>
                     </tr>


### PR DESCRIPTION
By default equateIL is enabled. This was wrongfully reported in the API documentation. This PR fixes this issue