### PR TITLE
Feature/homepage

### DIFF
--- a/src/components/analysis/multi/DemoAnalysisCard.vue
+++ b/src/components/analysis/multi/DemoAnalysisCard.vue
@@ -91,12 +91,10 @@
 import {SampleData} from "@/composables/communication/unipept/useSampleData";
 import {ref} from "vue";
 
-const { samples } = withDefaults(defineProps<{
+const { samples, disabled = false } = defineProps<{
     samples: SampleData[],
     disabled?: boolean
-}>(), {
-    disabled: false
-});
+}>();
 
 const emits = defineEmits<{
     (e: "select", sample: SampleData): void;

--- a/src/components/analysis/multi/DemoAnalysisCard.vue
+++ b/src/components/analysis/multi/DemoAnalysisCard.vue
@@ -48,7 +48,6 @@
                         >
                             <v-unipept-card
                                 class="d-flex flex-row align-center"
-                                @click="selectSample(sample)"
                                 style="min-height: 100%;"
                             >
                                 <div>
@@ -57,14 +56,24 @@
                                     </v-card-title>
                                     <v-card-text style="padding-top: 0 !important;">
                                         <div class="text-body-2 mb-2">{{ sample.reference }}</div>
-                                        <v-btn
-                                            color="primary"
-                                            variant="text"
-                                            style="z-index: 10000"
-                                            @click.stop="openReference(sample)"
-                                        >
-                                            View Article
-                                        </v-btn>
+                                        <div class="d-flex justify-end">
+                                            <v-btn
+                                                color="primary"
+                                                variant="text"
+                                                style="z-index: 10000"
+                                                @click.stop="openReference(sample)"
+                                            >
+                                                View Article
+                                            </v-btn>
+                                            <v-btn
+                                                color="primary"
+                                                variant="tonal"
+                                                style="z-index: 10000"
+                                                @click="selectSample(sample)"
+                                            >
+                                                Load sample
+                                            </v-btn>
+                                        </div>
                                     </v-card-text>
                                 </div>
                             </v-unipept-card>

--- a/src/components/analysis/multi/DemoAnalysisCard.vue
+++ b/src/components/analysis/multi/DemoAnalysisCard.vue
@@ -65,7 +65,9 @@
                                             >
                                                 View Article
                                             </v-btn>
+
                                             <v-btn
+                                                class="ms-1"
                                                 color="primary"
                                                 variant="tonal"
                                                 style="z-index: 10000"

--- a/src/components/analysis/multi/DemoAnalysisCard.vue
+++ b/src/components/analysis/multi/DemoAnalysisCard.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <v-unipept-card>
+        <v-unipept-card :disabled="disabled">
             <v-card-title>
                 <h2>New here? Try a sample dataset</h2>
             </v-card-title>
@@ -89,9 +89,12 @@
 import {SampleData} from "@/composables/communication/unipept/useSampleData";
 import {ref} from "vue";
 
-const { samples } = defineProps<{
-    samples: SampleData[]
-}>();
+const { samples } = withDefaults(defineProps<{
+    samples: SampleData[],
+    disabled?: boolean
+}>(), {
+    disabled: false
+});
 
 const emits = defineEmits<{
     (e: "select", sample: SampleData): void;

--- a/src/components/analysis/multi/NewAnalysisCard.vue
+++ b/src/components/analysis/multi/NewAnalysisCard.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <v-unipept-card>
+        <v-unipept-card :disabled="disabled">
             <v-card-title>
                 <h2>Start a new project</h2>
             </v-card-title>
@@ -66,9 +66,12 @@
 <script setup lang="ts">
 import {ref} from "vue";
 
-const props = defineProps<{
-    projects: { name: string, lastAccessed: Date }[]
-}>();
+const props = withDefaults(defineProps<{
+    projects: { name: string, lastAccessed: Date }[],
+    disabled?: boolean
+}>(), {
+    disabled: false
+});
 
 const emits = defineEmits<{
     (e: 'project:new', projectName: string): void

--- a/src/components/analysis/multi/NewAnalysisCard.vue
+++ b/src/components/analysis/multi/NewAnalysisCard.vue
@@ -66,12 +66,10 @@
 <script setup lang="ts">
 import {ref} from "vue";
 
-const props = withDefaults(defineProps<{
+const { projects, disabled = false } = defineProps<{
     projects: { name: string, lastAccessed: Date }[],
     disabled?: boolean
-}>(), {
-    disabled: false
-});
+}>();
 
 const emits = defineEmits<{
     (e: 'project:new', projectName: string): void
@@ -82,7 +80,7 @@ const newDialogOpen = ref(false);
 const projectName = ref('');
 
 const projectExists = (name: string) => {
-    return props.projects.some(project => project.name === name);
+    return projects.some(project => project.name === name);
 };
 
 const cancel = () => {

--- a/src/components/analysis/multi/NewAnalysisCard.vue
+++ b/src/components/analysis/multi/NewAnalysisCard.vue
@@ -2,27 +2,15 @@
     <div>
         <v-unipept-card>
             <v-card-title>
-                <h2>Advanced analysis</h2>
+                <h2>Start a new project</h2>
             </v-card-title>
+
             <v-card-text>
                 <p>
-                    Open an existing project (<em>.unipept</em>) or start from scratch with an empty project and analyse
-                    your own data.
+                    Start from scratch with an empty project and analyse your own data.
                 </p>
 
                 <div class="d-flex justify-end">
-                    <file-upload-button
-                        :loading="loading"
-                        class="mt-3 me-3 float-right"
-                        variant="plain"
-                        color="primary"
-                        text="Open project"
-                        prepend-icon="mdi-folder-open-outline"
-                        accept=".unipept"
-                        :multiple="false"
-                        @upload="openUploadDialog"
-                    />
-
                     <v-btn
                         class="mt-3 float-right"
                         variant="tonal"
@@ -72,73 +60,23 @@
                 </v-card-actions>
             </v-unipept-card>
         </v-dialog>
-
-        <v-dialog
-            v-model="uploadDialogOpen"
-            max-width="600"
-            persistent
-            @keydown.enter="() => projectName && openProject()"
-        >
-            <v-unipept-card>
-                <v-card-title class="text-h6 font-weight-bold">
-                    Upload project
-                </v-card-title>
-
-                <v-card-text class="pb-0">
-                    <v-alert
-                        v-if="projectExists(projectName)"
-                        class="mb-4"
-                        type="warning"
-                    >
-                        A project with the name <b>{{ projectName }}</b> already exists. You can either overwrite the
-                        existing project or choose a different name.
-                    </v-alert>
-
-                    <v-text-field
-                        v-model="projectName"
-                        label="Project name"
-                        variant="outlined"
-                        color="primary"
-                        placeholder="Enter a name for your project"
-                        :rules="[
-                            v => !!v || 'Project name is required'
-                        ]"
-                    />
-                </v-card-text>
-
-                <v-card-actions class="justify-end">
-                    <v-btn variant="text" @click="cancel">Cancel</v-btn>
-                    <v-btn
-                        color="primary"
-                        text="Upload project"
-                        :disabled="!projectName"
-                        @click="openProject"
-                    />
-                </v-card-actions>
-            </v-unipept-card>
-        </v-dialog>
     </div>
 </template>
 
 <script setup lang="ts">
-import FileUploadButton from "@/components/filesystem/FileUploadButton.vue";
 import {ref} from "vue";
 
 const props = defineProps<{
-    projects: { name: string, lastAccessed: Date }[],
-    loading: boolean
+    projects: { name: string, lastAccessed: Date }[]
 }>();
 
 const emits = defineEmits<{
-    (e: 'project:open', projectName: string, file: File): void
     (e: 'project:new', projectName: string): void
 }>();
 
 const newDialogOpen = ref(false);
-const uploadDialogOpen = ref(false);
 
 const projectName = ref('');
-const openProjectFile = ref<File | null>(null);
 
 const projectExists = (name: string) => {
     return props.projects.some(project => project.name === name);
@@ -146,20 +84,6 @@ const projectExists = (name: string) => {
 
 const cancel = () => {
     newDialogOpen.value = false;
-    uploadDialogOpen.value = false;
-    projectName.value = '';
-};
-
-const openUploadDialog = (file: File) => {
-    openProjectFile.value = file;
-    projectName.value = file.name.slice(0, -8);
-    uploadDialogOpen.value = true;
-};
-
-const openProject = () => {
-    uploadDialogOpen.value = false;
-    emits('project:open', projectName.value, openProjectFile.value!);
-    openProjectFile.value = null;
     projectName.value = '';
 };
 

--- a/src/components/analysis/multi/NewAnalysisCard.vue
+++ b/src/components/analysis/multi/NewAnalysisCard.vue
@@ -10,9 +10,9 @@
                     Start from scratch with an empty project and analyse your own data.
                 </p>
 
-                <div class="d-flex justify-end">
+                <div class="d-flex float-right">
                     <v-btn
-                        class="mt-3 float-right"
+                        class="mt-1 float-right"
                         variant="tonal"
                         color="primary"
                         text="Create new project"

--- a/src/components/analysis/multi/QuickAnalysisCard.vue
+++ b/src/components/analysis/multi/QuickAnalysisCard.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-unipept-card>
+    <v-unipept-card :disabled="disabled">
         <v-card-title>
             <h2>Quick analysis</h2>
         </v-card-title>
@@ -73,6 +73,12 @@
 <script setup lang="ts">
 import {ref} from "vue";
 import {AnalysisConfig} from "@/store/AnalysisConfig";
+
+const props = withDefaults(defineProps<{
+    disabled?: boolean
+}>(), {
+    disabled: false
+});
 
 const emits = defineEmits<{
     (e: "analyze", rawPeptides: string, config: AnalysisConfig): void;

--- a/src/components/analysis/multi/QuickAnalysisCard.vue
+++ b/src/components/analysis/multi/QuickAnalysisCard.vue
@@ -74,11 +74,9 @@
 import {ref} from "vue";
 import {AnalysisConfig} from "@/store/AnalysisConfig";
 
-const props = withDefaults(defineProps<{
+const { disabled = false } = defineProps<{
     disabled?: boolean
-}>(), {
-    disabled: false
-});
+}>();
 
 const emits = defineEmits<{
     (e: "analyze", rawPeptides: string, config: AnalysisConfig): void;

--- a/src/components/analysis/multi/QuickAnalysisCard.vue
+++ b/src/components/analysis/multi/QuickAnalysisCard.vue
@@ -59,17 +59,11 @@
                     </span>
                 </v-tooltip>
             </div>
-            <!--            <database-select-->
-            <!--                v-model="config.database"-->
-            <!--                class="mt-1"-->
-            <!--                label="Selected database"-->
-            <!--            />-->
             <v-btn
                 color="primary"
                 variant="tonal"
                 text="Analyze"
                 class="float-right"
-                :disabled="rawPeptides.length === 0"
                 @click="analyze"
             />
         </v-card-text>

--- a/src/components/analysis/multi/RecentAnalysisCard.vue
+++ b/src/components/analysis/multi/RecentAnalysisCard.vue
@@ -1,13 +1,26 @@
 <template>
     <div>
         <v-unipept-card :height="height">
-            <v-card-title ref="header">
+            <v-card-title ref="header" class="d-flex">
                 <h2 class="font-weight-light">
                     Load recent project
                 </h2>
+
+                <v-spacer />
+
+                <v-tooltip text="Open an existing project (.unipept)">
+                    <template v-slot:activator="{ props }">
+                        <upload-analysis-button
+                            v-bind="props"
+                            :projects="projects"
+                            :loading="loadingUpload"
+                            @project:upload="uploadProject"
+                        />
+                    </template>
+                </v-tooltip>
             </v-card-title>
 
-            <div v-if="loading" class="d-flex justify-center">
+            <div v-if="loadingOpen" class="d-flex justify-center">
                 <v-progress-circular color="primary" indeterminate />
             </div>
 
@@ -23,7 +36,7 @@
                         variant="flat"
                         density="compact"
                     >
-                        <v-card-text class="d-flex align-center gap-2">
+                        <v-card-text class="d-flex align-center gap-2 py-3">
                             <v-icon size="20" class="mr-5">mdi-folder-outline</v-icon>
                             <div>
                                 <div>{{ item.name }}</div>
@@ -35,7 +48,6 @@
                             </div>
 
                             <v-spacer />
-
 
                             <v-btn
                                 variant="text"
@@ -109,15 +121,18 @@
 import {ref, computed, watch, useTemplateRef, onMounted} from 'vue'
 import {useElementBounding} from "@vueuse/core";
 import {useNumberFormatter} from "@/composables/useNumberFormatter";
+import UploadAnalysisButton from "@/components/analysis/multi/UploadAnalysisButton.vue";
 
 const props = defineProps<{
     height: number,
     projects: { name: string, totalPeptides: number, lastAccessed: Date }[],
-    loading: boolean
+    loadingOpen: boolean,
+    loadingUpload: boolean
 }>();
 
 const emits = defineEmits<{
     (e: 'open', project: string): void
+    (e: 'upload', projectName: string, file: File): void
     (e: 'delete', project: string): void
 }>();
 
@@ -126,7 +141,7 @@ const { formatNumber } = useNumberFormatter();
 const header = useTemplateRef('header');
 const { height: headerHeight } = useElementBounding(header);
 
-const visibleCount = ref(5);
+const visibleCount = ref(4);
 const deleteDialogOpen = ref(false);
 const projectToDelete = ref<string>("");
 
@@ -144,6 +159,10 @@ const showMore = () => {
 
 const openProject = (projectName: string) => {
     emits('open', projectName)
+}
+
+const uploadProject = (projectName: string, file: File) => {
+    emits('upload', projectName, file);
 }
 
 const cancel = () => {

--- a/src/components/analysis/multi/RecentAnalysisCard.vue
+++ b/src/components/analysis/multi/RecentAnalysisCard.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <v-unipept-card :height="height">
+        <v-unipept-card :height="height" :disabled="disabled">
             <v-card-title ref="header" class="d-flex">
                 <h2 class="font-weight-light">
                     Load recent project
@@ -13,14 +13,14 @@
                         <upload-analysis-button
                             v-bind="props"
                             :projects="projects"
-                            :loading="loadingUpload"
+                            :loading="loading"
                             @project:upload="uploadProject"
                         />
                     </template>
                 </v-tooltip>
             </v-card-title>
 
-            <div v-if="loadingOpen" class="d-flex justify-center">
+            <div v-if="loading" class="d-flex flex-column justify-center align-center h-100">
                 <v-progress-circular color="primary" indeterminate />
             </div>
 
@@ -122,12 +122,13 @@ import {ref, computed, watch, useTemplateRef, onMounted} from 'vue'
 import {useElementBounding} from "@vueuse/core";
 import {useNumberFormatter} from "@/composables/useNumberFormatter";
 import UploadAnalysisButton from "@/components/analysis/multi/UploadAnalysisButton.vue";
+import {load} from "webfontloader";
 
 const props = defineProps<{
     height: number,
     projects: { name: string, totalPeptides: number, lastAccessed: Date }[],
-    loadingOpen: boolean,
-    loadingUpload: boolean
+    loading: boolean,
+    disabled: boolean
 }>();
 
 const emits = defineEmits<{

--- a/src/components/analysis/multi/UploadAnalysisButton.vue
+++ b/src/components/analysis/multi/UploadAnalysisButton.vue
@@ -1,7 +1,6 @@
 <template>
     <div>
         <file-upload-button
-            :loading="loading"
             variant="tonal"
             color="primary"
             text="Open project"

--- a/src/components/analysis/multi/UploadAnalysisButton.vue
+++ b/src/components/analysis/multi/UploadAnalysisButton.vue
@@ -1,0 +1,104 @@
+<template>
+    <div>
+        <file-upload-button
+            :loading="loading"
+            variant="tonal"
+            color="primary"
+            text="Open project"
+            prepend-icon="mdi-folder-open-outline"
+            accept=".unipept"
+            :multiple="false"
+            @upload="openUploadDialog"
+        />
+
+        <v-dialog
+            v-model="uploadDialogOpen"
+            max-width="600"
+            persistent
+            @keydown.enter="() => projectName && openProject()"
+        >
+            <v-unipept-card>
+                <v-card-title class="text-h6 font-weight-bold">
+                    Upload project
+                </v-card-title>
+
+                <v-card-text class="pb-0">
+                    <v-alert
+                        v-if="projectExists(projectName)"
+                        class="mb-4"
+                        type="warning"
+                    >
+                        A project with the name <b>{{ projectName }}</b> already exists. You can either overwrite the
+                        existing project or choose a different name.
+                    </v-alert>
+
+                    <v-text-field
+                        v-model="projectName"
+                        label="Project name"
+                        variant="outlined"
+                        color="primary"
+                        placeholder="Enter a name for your project"
+                        :rules="[
+                            v => !!v || 'Project name is required'
+                        ]"
+                    />
+                </v-card-text>
+
+                <v-card-actions class="justify-end">
+                    <v-btn variant="text" @click="cancel">Cancel</v-btn>
+                    <v-btn
+                        color="primary"
+                        text="Upload project"
+                        :disabled="!projectName"
+                        @click="openProject"
+                    />
+                </v-card-actions>
+            </v-unipept-card>
+        </v-dialog>
+    </div>
+</template>
+
+<script setup lang="ts">
+import FileUploadButton from "@/components/filesystem/FileUploadButton.vue";
+import {ref} from "vue";
+
+const props = defineProps<{
+    projects: { name: string, lastAccessed: Date }[],
+    loading: boolean
+}>();
+
+const emits = defineEmits<{
+    (e: 'project:upload', projectName: string, file: File): void
+}>();
+
+const uploadDialogOpen = ref(false);
+
+const projectName = ref('');
+const openProjectFile = ref<File | null>(null);
+
+const projectExists = (name: string) => {
+    return props.projects.some(project => project.name === name);
+};
+
+const cancel = () => {
+    uploadDialogOpen.value = false;
+    projectName.value = '';
+};
+
+const openUploadDialog = (file: File) => {
+    openProjectFile.value = file;
+    projectName.value = file.name.slice(0, -8);
+    uploadDialogOpen.value = true;
+};
+
+const openProject = () => {
+    uploadDialogOpen.value = false;
+    emits('project:upload', projectName.value, openProjectFile.value!);
+    openProjectFile.value = null;
+    projectName.value = '';
+};
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/filesystem/FileUploadButton.vue
+++ b/src/components/filesystem/FileUploadButton.vue
@@ -6,6 +6,7 @@
             :variant="variant"
             :color="color"
             :loading="loading"
+            :disabled="disabled"
             @click="triggerFileInput"
         />
 
@@ -30,6 +31,7 @@ const fileInput = useTemplateRef("fileInput");
 withDefaults(defineProps<{
     multiple?: boolean
     loading?: boolean
+    disabled?: boolean
     color?: string
     variant?: "flat" | "text" | "elevated" | "tonal" | "outlined" | "plain" | undefined
     prependIcon?: string
@@ -38,6 +40,7 @@ withDefaults(defineProps<{
 }>(), {
     multiple: false,
     loading: false,
+    disabled: false,
     color: "primary",
     variant: "outlined",
     prependIcon: "mdi-upload",

--- a/src/components/pages/features/analysis/MetaproteomeHomePage.vue
+++ b/src/components/pages/features/analysis/MetaproteomeHomePage.vue
@@ -4,11 +4,13 @@
             <v-col cols="6">
                 <div ref="firstColumn">
                     <quick-analysis-card
+                        :disabled="loadingProject || loadingSampleData"
                         @analyze="quickAnalyze"
                     />
 
                     <demo-analysis-card
                         class="mt-5"
+                        :disabled="loadingProject || loadingSampleData"
                         :samples="sampleDataStore.samples"
                         @select="demoAnalyze"
                     />
@@ -19,6 +21,7 @@
                 <div ref="topCard">
                     <new-analysis-card
                         :projects="projects"
+                        :disabled="loadingProject || loadingSampleData"
                         @project:new="advancedAnalyze"
                     />
                 </div>
@@ -27,6 +30,7 @@
                     class="mt-5"
                     :height="bottomCardHeight"
                     :projects="projects"
+                    :disabled="loadingProject || loadingSampleData"
                     :loading="loadingProject"
                     @open="loadFromIndexedDB"
                     @upload="importProject"
@@ -73,7 +77,6 @@ const bottomCardHeight = computed(() => firstColumnHeight.value - topCardHeight.
 
 const loadingSampleData: Ref<boolean> = ref(true);
 const loadingProject: Ref<boolean> = ref(false);
-const importingProject: Ref<boolean> = ref(false);
 
 const projects = ref<{ name: string, totalPeptides: number, lastAccessed: Date }[]>([]);
 
@@ -84,11 +87,11 @@ const quickAnalyze = async (rawPeptides: string, config: AnalysisConfig) => {
 }
 
 const importProject = async (projectName: string, file: File) => {
-    importingProject.value = true;
+    loadingProject.value = true;
     await loadProjectFromFile(projectName, file)
     await router.push({ name: "mpaSingle" });
     await startImport();
-    importingProject.value = false;
+    loadingProject.value = false;
 }
 
 const loadFromIndexedDB = async (projectName: string) => {

--- a/src/components/pages/features/analysis/MetaproteomeHomePage.vue
+++ b/src/components/pages/features/analysis/MetaproteomeHomePage.vue
@@ -19,9 +19,7 @@
                 <div ref="topCard">
                     <new-analysis-card
                         :projects="projects"
-                        :loading="importingProject"
                         @project:new="advancedAnalyze"
-                        @project:open="importProject"
                     />
                 </div>
 
@@ -31,6 +29,7 @@
                     :projects="projects"
                     :loading="loadingProject"
                     @open="loadFromIndexedDB"
+                    @upload="importProject"
                     @delete="deleteFromIndexedDB"
                 />
             </v-col>

--- a/src/components/pages/features/analysis/MetaproteomeHomePage.vue
+++ b/src/components/pages/features/analysis/MetaproteomeHomePage.vue
@@ -4,7 +4,7 @@
             <v-col cols="6">
                 <div ref="firstColumn">
                     <quick-analysis-card
-                        :disabled="loadingProject || loadingSampleData"
+                        :disabled="loadingProject"
                         @analyze="quickAnalyze"
                     />
 
@@ -21,7 +21,7 @@
                 <div ref="topCard">
                     <new-analysis-card
                         :projects="projects"
-                        :disabled="loadingProject || loadingSampleData"
+                        :disabled="loadingProject"
                         @project:new="advancedAnalyze"
                     />
                 </div>
@@ -30,7 +30,7 @@
                     class="mt-5"
                     :height="bottomCardHeight"
                     :projects="projects"
-                    :disabled="loadingProject || loadingSampleData"
+                    :disabled="loadingProject"
                     :loading="loadingProject"
                     @open="loadFromIndexedDB"
                     @upload="importProject"


### PR DESCRIPTION
Improve some items on the MPA homepage:
- Give "new project" its own card, rather than sharing it with the upload functionality
- Move the upload to the "recent projects" section
- Explicit buttons to select a sample dataset
- Improved loading when opening or uploading an analysis
- Give each section only one primary button