### PR TITLE
Fix all Is were wrongly replaced by Ls by the web app

### DIFF
--- a/src/composables/processing/peptide/usePeptideProcessor.ts
+++ b/src/composables/processing/peptide/usePeptideProcessor.ts
@@ -6,7 +6,6 @@ import {ShareableMap, TransferableState} from "shared-memory-datastructures";
 
 export interface PeptideProcessorData {
     peptides: string[];
-    equate: boolean;
     filter: boolean;
 }
 
@@ -24,7 +23,7 @@ export default function usePeptideProcessor() {
 
     const process = async (peptides: string[], equate: boolean, filter: boolean) => {
         const { peptideCountsTransferable, totalPeptideCount } = await post({
-            peptides, equate, filter
+            peptides, filter
         });
 
         const countTableMap = ShareableMap.fromTransferableState<string, number>(peptideCountsTransferable);

--- a/src/composables/processing/workers/peptideProcessor.worker.ts
+++ b/src/composables/processing/workers/peptideProcessor.worker.ts
@@ -12,10 +12,9 @@ self.onmessage = async (event) => {
 
 const process = async ({
     peptides,
-    equate,
     filter
 }: PeptideProcessorData) => {
-    peptides = preprocess(peptides, equate);
+    peptides = preprocess(peptides);
 
     const peptideCounts = new ShareableMap<string, number>();
     for (const peptide of peptides) {
@@ -32,10 +31,8 @@ const process = async ({
 }
 
 const preprocess = (
-    peptides: string[],
-    equate: boolean
+    peptides: string[]
 ) => {
     return peptides
-        .filter((p) => p.length >= 5)
-        .map(p => equate ? p.replace(/I/g, 'L') : p);
+        .filter((p) => p.length >= 5);
 }


### PR DESCRIPTION
When the "equate I/L" option was enabled in the web app, all occurrences of I in a peptide were replaced by L. However, this causes the original peptides to no longer be found in the final output file. The Unipept API can handle this by correctly passing the `equate`-parameter in calls to the `/mpa/pept2data` endpoint, which is done by this PR now.