### PR TITLE
Fix removal of rows in the comparative heatmap

### DIFF
--- a/src/components/analysis/comparative/ComparativeHeatmap.vue
+++ b/src/components/analysis/comparative/ComparativeHeatmap.vue
@@ -772,6 +772,7 @@ const initializeData = () => {
 const addRow = (feature: TableFeature) => {
     if (!selectedIds.value.includes(feature.id)) {
         selectedIds.value.push(feature.id);
+        rows.value = selectedIds.value.map(id => featureItems.value.get(id)!);
     }
 };
 
@@ -792,6 +793,8 @@ const removeRow = (index: number) => {
     }
 
     selectedIds.value.splice(index, 1);
+    visibleItems.value.splice(index, 1);
+    rows.value = selectedIds.value.map(id => featureItems.value.get(id)!);
 }
 
 const removeRows = (rows: TableFeature[]) => {


### PR DESCRIPTION
This PR provides a fix for issue #1695.