### PR TITLE
Fix navigation drawer switched to mobile view too soon

### DIFF
--- a/src/components/project/ProjectView.vue
+++ b/src/components/project/ProjectView.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- Persistent mobile toggle button that stays visible when drawer is closed -->
     <v-btn
-        v-if="$vuetify.display.mobile && !drawerOpen"
+        v-if="$vuetify.display.smAndDown && !drawerOpen"
         icon
         variant="tonal"
         color="primary"
@@ -15,10 +15,10 @@
 
     <v-navigation-drawer
         v-model="drawerOpen"
-        mobile-breakpoint="md"
-        :permanent="!$vuetify.display.mobile"
-        :temporary="$vuetify.display.mobile"
-        :location="$vuetify.display.mobile ? 'bottom' : undefined"
+        mobile-breakpoint="sm"
+        :permanent="!$vuetify.display.smAndDown"
+        :temporary="$vuetify.display.smAndDown"
+        :location="$vuetify.display.smAndDown ? 'bottom' : undefined"
     >
         <template #prepend>
             <div class="d-flex align-center">
@@ -32,7 +32,7 @@
                     {{ project.name }}
                 </v-list-subheader>
                 <v-btn
-                    v-if="$vuetify.display.mobile"
+                    v-if="$vuetify.display.smAndDown"
                     icon
                     variant="text"
                     size="small"


### PR DESCRIPTION
Since version 6.3.1 of Unipept, the UI of the app has been optimized for smaller devices (i.e. tablets, phones or small laptops). If the window is too small, the sidebar is updated and moves to the bottom of the screen. The switch to the mobile version of the navigation drawer, however, was made too soon (i.e. also for screens that are still wide enough to display the full navigation drawer).

This PR changes that behaviour and only displays the mobile nav drawer on screen sizes categorized as "sm" or smaller (instead of "md" or smaller).