### PR TITLE
Implemented download project dialog for project exports

### DIFF
--- a/src/components/analysis/multi/AnalysisSummaryExport.vue
+++ b/src/components/analysis/multi/AnalysisSummaryExport.vue
@@ -1,97 +1,61 @@
 <template>
-    <div class="d-flex flex-column">
-        <v-menu>
-            <template #activator="{ props }">
-                <v-btn
-                    v-bind="props"
-                    text="Export results"
-                    color="primary"
-                    variant="tonal"
-                    prepend-icon="mdi-download"
-                    append-icon="mdi-chevron-down"
-                    :loading="loading"
-                />
-            </template>
-            <v-list density="compact">
-                <v-list-item
-                    density="compact"
-                    @click="prepareDownload(',')"
-                >
-                    Comma separated (international)
-                </v-list-item>
-                <v-list-item
-                    density="compact"
-                    @click="prepareDownload(';')"
-                >
-                    Semicolon separated (European)
-                </v-list-item>
-                <v-list-item
-                    density="compact"
-                    @click="prepareDownload('\t')"
-                >
-                    Tab separated
-                </v-list-item>
-            </v-list>
-        </v-menu>
-        <v-dialog
-            v-model="dialogOpen"
-            width="400px"
-        >
-            <v-card>
-                <v-card-title class="d-flex align-center">
-                    <h2 v-if="loading">Preparing download</h2>
-                    <h2 v-else>Download ready</h2>
-                    <v-spacer />
-                    <div class="justify-end">
-                        <v-btn
-                            icon="mdi-close"
-                            variant="plain"
-                            density="compact"
-                            @click="dialogOpen = false"
-                        />
-                    </div>
-                </v-card-title>
-                <v-card-text>
-                    <div v-if="loading" class="d-flex justify-center">
-                        <v-progress-circular color="primary" indeterminate />
-                    </div>
-                    <div v-else class="d-flex justify-center flex-column">
-                        We finished preparing your export. Click the button below to save the file to your computer.
-                        <v-btn
-                            @click="download"
-                            color="primary"
-                            variant="tonal"
-                            text="Download"
-                            prepend-icon="mdi-download"
-                            class="mt-2"
-                        />
-                    </div>
-                </v-card-text>
-            </v-card>
-        </v-dialog>
-    </div>
+    <download-dialog @download="download">
+        <template #default="{ startPreparing }">
+            <v-menu>
+                <template #activator="{ props }">
+                    <v-btn
+                        v-bind="props"
+                        text="Export results"
+                        color="primary"
+                        variant="tonal"
+                        prepend-icon="mdi-download"
+                        append-icon="mdi-chevron-down"
+                        :loading="loading"
+                    />
+                </template>
+                <v-list density="compact">
+                    <v-list-item
+                        density="compact"
+                        @click="startPreparing(prepareDownload(','))"
+                    >
+                        Comma separated (international)
+                    </v-list-item>
+                    <v-list-item
+                        density="compact"
+                        @click="startPreparing(prepareDownload(';'))"
+                    >
+                        Semicolon separated (European)
+                    </v-list-item>
+                    <v-list-item
+                        density="compact"
+                        @click="startPreparing(prepareDownload('\t'))"
+                    >
+                        Tab separated
+                    </v-list-item>
+                </v-list>
+            </v-menu>
+        </template>
+    </download-dialog>
 </template>
 
 <script setup lang="ts">
-import {Ref, ref} from "vue";
+import DownloadDialog from "@/components/dialogs/DownloadDialog.vue";
+import {ref, Ref} from "vue";
 
 const emits = defineEmits<{
     (e: 'prepareDownload', delimiter: string, callback: () => void): Promise<void>,
     (e: 'download', callback: () => void): Promise<void>
 }>();
 
-const dialogOpen: Ref<boolean> = ref(false);
 const loading: Ref<boolean> = ref(false);
 
 const prepareDownload = async (delimiter: string): Promise<void> => {
     loading.value = true;
-    dialogOpen.value = true;
     await new Promise<void>(resolve => emits("prepareDownload", delimiter, () => resolve()));
     loading.value = false;
 }
 
-const download = async (): Promise<void> => {
-    await new Promise<void>(resolve => emits("download", () => resolve()));
-    dialogOpen.value = false;
+const download = async (callback: () => void): Promise<void> => {
+    await emits("download", callback);
 }
 </script>

--- a/src/components/analysis/multi/MissingPeptidesDialog.vue
+++ b/src/components/analysis/multi/MissingPeptidesDialog.vue
@@ -78,7 +78,6 @@ const headers = [
 ];
 
 const blastPeptide = (peptide: string) => {
-    // TODO: change this. Hardcoded link to website for testing purposes
     const a = document.createElement('a');
     a.href = `http://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE_TYPE=BlastSearch&SET_SAVED_SEARCH=on
         &USER_FORMAT_DEFAULTS=on&PAGE=Proteins&PROGRAM=blastp&QUERY=${peptide}&GAPCOSTS=11%201

--- a/src/components/dialogs/DownloadDialog.vue
+++ b/src/components/dialogs/DownloadDialog.vue
@@ -1,0 +1,79 @@
+<!--
+    This dialog component is designed to handle file downloads in a browser-friendly way.
+    It displays a loading state while a file is being prepared and then shows a download
+    button only when the file is ready. This approach prevents browser download blocking
+    that can occur when there's a long delay between the user's click and the actual
+    download start. Instead, this component waits for the file to be ready before actually
+    allowing the user to initiate the download.
+-->
+<template>
+    <slot :start-preparing="startPreparing" />
+    <v-dialog
+        v-model="dialogOpen"
+        width="400px"
+    >
+        <v-card>
+            <v-card-title class="d-flex align-center">
+                <h2 v-if="loading">Preparing download</h2>
+                <h2 v-else>Download ready</h2>
+                <v-spacer />
+                <div class="justify-end">
+                    <v-btn
+                        icon="mdi-close"
+                        variant="plain"
+                        density="compact"
+                        @click="dialogOpen = false"
+                    />
+                </div>
+            </v-card-title>
+            <v-card-text>
+                <div v-if="loading" class="d-flex justify-center">
+                    <v-progress-circular color="primary" indeterminate />
+                </div>
+                <div v-else class="d-flex justify-center flex-column">
+                    We finished preparing your export. Click the button below to save the file to your computer.
+                    <v-btn
+                        @click="download"
+                        color="primary"
+                        variant="tonal"
+                        text="Download"
+                        prepend-icon="mdi-download"
+                        class="mt-2"
+                    />
+                </div>
+            </v-card-text>
+        </v-card>
+    </v-dialog>
+</template>
+
+<script setup lang="ts">
+import {Ref, ref} from "vue";
+
+const dialogOpen: Ref<boolean> = ref(false);
+const loading: Ref<boolean> = ref(false);
+
+/**
+ * Events emitted by the download dialog
+ * @event download - Emitted when the user clicks the download button
+ * @param {Function} callback - Callback function to be called when the download is complete
+ */
+const emits = defineEmits<{
+    (e: 'download', callback: () => void): Promise<void>
+}>();
+
+const download = async (): Promise<void> => {
+    await new Promise<void>(resolve => emits("download", () => resolve()));
+    dialogOpen.value = false;
+}
+
+const startPreparing = async (callback: Promise<void>) => {
+    dialogOpen.value = true;
+    loading.value = true;
+    await callback;
+    loading.value = false;
+}
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
This PR provides a fix for #1700. Downloads for an exported project are now also presented through an async dialog component. 