### PR TITLE
Update tracking link for Umami to self-hosted instance

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Unipept</title>
         <!-- Umami Analytics -->
-        <script defer crossorigin="anonymous" src="https://cloud.umami.is/script.js" data-website-id="82e92c0d-f0b5-4d18-8020-cfcd53cd3669" data-domains="unipept.ugent.be"></script>
+        <script defer src="https://umami.compomics.com/script.js" data-website-id="76bcd901-edf7-4937-9973-1b1e21f3a477" data-domains="unipept.ugent.be"></script>
     </head>
     <body>
         <div id="app"></div>


### PR DESCRIPTION
Switch the Umami analysis tracking from the commercial Umami host to a self-hosted version.