### PR TITLE
Fix totalPeptides field in old projects in browser memory inaccessible

### DIFF
--- a/src/store/UnipeptAnalysisStore.ts
+++ b/src/store/UnipeptAnalysisStore.ts
@@ -36,7 +36,7 @@ const useUnipeptAnalysisStore = defineStore('PersistedAnalysisStore', () => {
             const value: StoreValue | null = await store.getItem(key);
             return {
                 name: key,
-                totalPeptides: value!.totalPeptides,
+                totalPeptides: value?.totalPeptides || 0,
                 lastAccessed: new Date(value!.lastAccessed)
             };
         }));


### PR DESCRIPTION
Projects that are stored in the browser's IndexedDB and that have been made some time ago where missing the `totalPeptides` field. This field, however, was expected to be there when loading in the project's metadata, causing Unipept to crash.

This PR fixes this issue by using `0 peptides` as a placeholder when the `totalPeptides` field is non-existing. The total peptides count will be correct the next time this project is opened again in Unipept. 