### PR TITLE
Refactor: Replace localforage with native IndexedDB implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "highcharts-vue": "^2.0.1",
     "html-to-image": "^1.11.11",
     "jszip": "^3.10.1",
-    "localforage": "^1.10.0",
     "lru-cache-idb": "^0.5.2",
     "marked": "^17.0.1",
     "peptonizer": "file:./peptonizer-v0.0.31.tgz",

--- a/src/logic/storage/IndexedDBStore.ts
+++ b/src/logic/storage/IndexedDBStore.ts
@@ -1,0 +1,102 @@
+export default class IndexedDBStore {
+    private dbName: string;
+    private storeName: string;
+    private db: IDBDatabase | null = null;
+
+    constructor(dbName: string, storeName: string) {
+        this.dbName = dbName;
+        this.storeName = storeName;
+    }
+
+    private async getDB(): Promise<IDBDatabase> {
+        if (this.db) return this.db;
+
+        return new Promise((resolve, reject) => {
+            const request = indexedDB.open(this.dbName);
+
+            request.onupgradeneeded = (event) => {
+                const db = (event.target as IDBOpenDBRequest).result;
+                if (!db.objectStoreNames.contains(this.storeName)) {
+                    db.createObjectStore(this.storeName);
+                }
+            };
+
+            request.onsuccess = (event) => {
+                this.db = (event.target as IDBOpenDBRequest).result;
+                resolve(this.db!);
+            };
+
+            request.onerror = (event) => {
+                reject((event.target as IDBOpenDBRequest).error);
+            };
+        });
+    }
+
+    async getItem<T>(key: string): Promise<T | null> {
+        const db = await this.getDB();
+        return new Promise((resolve, reject) => {
+            const transaction = db.transaction(this.storeName, "readonly");
+            const store = transaction.objectStore(this.storeName);
+            const request = store.get(key);
+
+            request.onsuccess = () => {
+                resolve(request.result === undefined ? null : request.result);
+            };
+
+            request.onerror = () => {
+                reject(request.error);
+            };
+        });
+    }
+
+    async setItem<T>(key: string, value: T): Promise<void> {
+        const db = await this.getDB();
+        return new Promise((resolve, reject) => {
+            const transaction = db.transaction(this.storeName, "readwrite");
+            const store = transaction.objectStore(this.storeName);
+            const request = store.put(value, key);
+
+            request.onsuccess = () => {
+                resolve();
+            };
+
+            request.onerror = () => {
+                reject(request.error);
+            };
+        });
+    }
+
+    async removeItem(key: string): Promise<void> {
+        const db = await this.getDB();
+        return new Promise((resolve, reject) => {
+            const transaction = db.transaction(this.storeName, "readwrite");
+            const store = transaction.objectStore(this.storeName);
+            const request = store.delete(key);
+
+            request.onsuccess = () => {
+                resolve();
+            };
+
+            request.onerror = () => {
+                reject(request.error);
+            };
+        });
+    }
+
+    async keys(): Promise<string[]> {
+        const db = await this.getDB();
+        return new Promise((resolve, reject) => {
+            const transaction = db.transaction(this.storeName, "readonly");
+            const store = transaction.objectStore(this.storeName);
+            const request = store.getAllKeys();
+
+            request.onsuccess = () => {
+                resolve(request.result as string[]);
+            };
+
+            request.onerror = () => {
+                reject(request.error);
+            };
+        });
+    }
+}

--- a/src/store/UnipeptAnalysisStore.ts
+++ b/src/store/UnipeptAnalysisStore.ts
@@ -1,6 +1,6 @@
 import {defineStore} from "pinia";
 import useProjectAnalysisStore from "@/store/ProjectAnalysisStore";
-import localforage from "localforage";
+import IndexedDBStore from "@/logic/storage/IndexedDBStore";
 import {SampleData} from "@/composables/communication/unipept/useSampleData";
 import {AnalysisConfig} from "@/store/AnalysisConfig";
 import useCustomFilterStore, {UNIPROT_ID} from "@/store/CustomFilterStore";
@@ -17,11 +17,7 @@ interface StoreValue {
 }
 
 const useUnipeptAnalysisStore = defineStore('PersistedAnalysisStore', () => {
-    const store = localforage.createInstance({
-        driver: localforage.INDEXEDDB,
-        storeName: 'projects',
-        name: 'unipept',
-    });
+    const store = new IndexedDBStore("unipept", "projects");
 
     const { process: storeToBlob } = useProjectExport();
     const { process: blobToStore } = useProjectImport();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,7 +65,6 @@ export default defineConfig({
             "d3",
             "highcharts",
             "highcharts-vue",
-            "localforage",
             "marked",
             "html-to-image"
         ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2352,13 +2352,6 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-lie@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
-  integrity sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==
-  dependencies:
-    immediate "~3.0.5"
-
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
@@ -2374,13 +2367,6 @@ local-pkg@^1.0.0:
     mlly "^1.7.4"
     pkg-types "^2.3.0"
     quansync "^0.2.11"
-
-localforage@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
-  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
-  dependencies:
-    lie "3.1.1"
 
 locate-path@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Removed the localforage dependency and replaced it with a custom IndexedDBStore class that uses the native IndexedDB API. This reduces the bundle size and removes an extra dependency. The implementation maintains compatibility with existing data by using the same database ('unipept') and object store ('projects') names as the previous configuration. Verified with E2E tests.

---
*PR created automatically by Jules for task [1790786266232008843](https://jules.google.com/task/1790786266232008843) started by @pverscha*