### PR TITLE
Implement filter and search functionality for peptide summary table

### DIFF
--- a/src/components/analysis/multi/AnalysisSummary.vue
+++ b/src/components/analysis/multi/AnalysisSummary.vue
@@ -144,7 +144,7 @@
                 <v-col cols="12" lg="4" class="pb-0 mb-n3">
                     <analysis-summary-export @prepareDownload="prepareDownload" @download="download" />
                 </v-col>
-                <v-col cols="12" class="pt-0">
+                <v-col cols="12" class="pt-0 mt-n2">
                     <analysis-summary-table :analysis="analysis" />
                 </v-col>
             </v-row>

--- a/src/components/analysis/multi/AnalysisSummary.vue
+++ b/src/components/analysis/multi/AnalysisSummary.vue
@@ -136,15 +136,15 @@
                 </v-col>
             </v-row>
             <v-row>
-                <v-col cols="12" lg="8" class="pb-0">
+                <v-col cols="12" lg="8" class="pb-0 mb-n3">
                     <h2>
                         Peptide matches
                     </h2>
                 </v-col>
-                <v-col cols="12" lg="4" class="pb-0 pb-1">
+                <v-col cols="12" lg="4" class="pb-0 mb-n3">
                     <analysis-summary-export @prepareDownload="prepareDownload" @download="download" />
                 </v-col>
-                <v-col cols="12">
+                <v-col cols="12" class="pt-0">
                     <analysis-summary-table :analysis="analysis" />
                 </v-col>
             </v-row>

--- a/src/components/analysis/multi/AnalysisSummaryTable.vue
+++ b/src/components/analysis/multi/AnalysisSummaryTable.vue
@@ -384,6 +384,11 @@ a:hover {
     text-decoration: none;
 }
 
+/* Lighter border for inactive (outlined) quick filter chips */
+:deep(.v-chip--variant-outlined) {
+    border-color: rgba(0, 0, 0, 0.18) !important;
+}
+
 /* Align prepend icons vertically with chip text */
 :deep(.chip-icon) {
     font-size: 14px !important;

--- a/src/components/analysis/multi/AnalysisSummaryTable.vue
+++ b/src/components/analysis/multi/AnalysisSummaryTable.vue
@@ -1,185 +1,311 @@
 <template>
-    <v-data-table-server
-        mobile-breakpoint="md"
-        :headers="headers"
-        :items="shownItems"
-        :items-per-page="5"
-        :items-length="analysis.peptidesTable!.totalCount"
-        density="compact"
-        :disable-sort="true"
-        style="background-color: transparent"
-        @update:options="computeShownItems"
-    >
-        <template #no-data>
-            <v-alert
-                class="ma-3"
-                density="compact"
-                type="info"
-                variant="tonal"
-                text="No peptides found"
-            />
-        </template>
+    <div>
+        <!-- ── Search bar with hints dropdown ─────────────────────────────────── -->
+        <v-row density="compact" class="mb-1 px-1">
+            <v-col cols="12" style="position: relative;">
+                <v-text-field
+                    :model-value="search"
+                    density="compact"
+                    variant="outlined"
+                    hide-details
+                    clearable
+                    prepend-inner-icon="mdi-magnify"
+                    autocomplete="off"
+                    placeholder='Try “sus scrofa”, “rank:species”, or just “GO”…'
+                    @focus="onSearchFocus"
+                    @blur="onSearchBlur"
+                    @update:model-value="handleSearchInput"
+                    @click:clear="handleClear"
+                    @keydown.escape="hintsOpen = false"
+                />
 
-        <template #item.peptide="{ item }">
-            <a
-                class="cursor-pointer"
-                @click="openPeptideAnalysis(item.peptide)"
-                :style="$vuetify.display.mobile ? 'display: inline-block; max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;' : ''"
-            >
-                {{ item.peptide }}
-            </a>
-        </template>
-
-        <template #item.faCounts="{ item }">
-            <v-tooltip v-if="item.faCounts" location="top">
-                <template #activator="{ props }">
-                    <v-avatar
-                        v-bind="props"
-                        size="30"
-                        :color="item.faCounts.go > 0 ? 'amber' : 'amber-lighten-4'"
-                        class="me-1"
-                    >
-                        <span
-                            :class="[ item.faCounts.go > 0 ? 'text-black' : 'text-grey', 'headline']"
-                            style="font-size: 14px !important;"
+                <!-- Hints dropdown -->
+                <v-card
+                    v-if="hintsOpen"
+                    class="hints-dropdown"
+                    elevation="8"
+                    rounded="lg"
+                >
+                    <div class="hints-header px-4 pt-3 pb-1">TRY TYPING&hellip;</div>
+                    <v-list density="compact" class="px-2 pb-2">
+                        <v-list-item
+                            v-for="hint in searchHints"
+                            :key="hint.query"
+                            rounded="lg"
+                            class="hint-item"
+                            @mousedown.prevent
+                            @click="applyHint(hint.query)"
                         >
-                            GO
-                        </span>
-                    </v-avatar>
-                </template>
+                            <div class="d-flex align-center">
+                                <code :class="['hint-query', 'me-4', hint.color ? `text-${hint.color}` : 'text-medium-emphasis']">
+                                    {{ hint.query }}
+                                </code>
+                                <span class="text-body-2 text-medium-emphasis">{{ hint.description }}</span>
+                            </div>
+                        </v-list-item>
+                    </v-list>
+                </v-card>
+            </v-col>
+        </v-row>
 
-                <span v-if="item.faCounts.go > 0">
-                    This peptide is annotated with {{ item.faCounts.go }}
-                    <span class="font-weight-bold">
-                        {{ item.faCounts.go === 1 ? "GO-term" : "GO-terms" }}.
-                    </span>
+        <!-- ── Quick filters + peptide count ─────────────────────────────────── -->
+        <v-row density="compact" class="mb-2 px-1 align-center">
+            <v-col cols="12" md="auto" class="d-flex align-center flex-wrap ga-1">
+                <span class="text-caption text-medium-emphasis me-1">Quick filters:</span>
+
+                <v-chip
+                    :color="quickFilters.speciesLevel ? 'blue' : undefined"
+                    :variant="quickFilters.speciesLevel ? 'flat' : 'outlined'"
+                    :class="quickFilters.speciesLevel ? 'text-white' : ''"
+                    size="small"
+                    @click="onQuickFilterChange({ ...quickFilters, speciesLevel: !quickFilters.speciesLevel })"
+                >
+                    <template #prepend><v-icon class="chip-icon">mdi-bacteria-outline</v-icon></template>
+                    Species level
+                </v-chip>
+
+                <v-chip
+                    :color="quickFilters.hasGo ? 'amber' : undefined"
+                    :variant="quickFilters.hasGo ? 'flat' : 'outlined'"
+                    size="small"
+                    @click="onQuickFilterChange({ ...quickFilters, hasGo: !quickFilters.hasGo })"
+                >
+                    <template #prepend><v-icon class="chip-icon">mdi-function-variant</v-icon></template>
+                    Has GO terms
+                </v-chip>
+
+                <v-chip
+                    :color="quickFilters.hasEc ? 'indigo' : undefined"
+                    :variant="quickFilters.hasEc ? 'flat' : 'outlined'"
+                    :class="quickFilters.hasEc ? 'text-white' : ''"
+                    size="small"
+                    @click="onQuickFilterChange({ ...quickFilters, hasEc: !quickFilters.hasEc })"
+                >
+                    <template #prepend><v-icon class="chip-icon">mdi-flask-outline</v-icon></template>
+                    Has EC numbers
+                </v-chip>
+
+                <v-chip
+                    :color="quickFilters.hasIpr ? 'red' : undefined"
+                    :variant="quickFilters.hasIpr ? 'flat' : 'outlined'"
+                    :class="quickFilters.hasIpr ? 'text-white' : ''"
+                    size="small"
+                    @click="onQuickFilterChange({ ...quickFilters, hasIpr: !quickFilters.hasIpr })"
+                >
+                    <template #prepend><v-icon class="chip-icon">mdi-database-search-outline</v-icon></template>
+                    Has InterPro
+                </v-chip>
+
+                <v-chip
+                    :color="quickFilters.notFound ? 'orange' : undefined"
+                    :variant="quickFilters.notFound ? 'flat' : 'outlined'"
+                    :class="quickFilters.notFound ? 'text-white' : ''"
+                    size="small"
+                    @click="onQuickFilterChange({ ...quickFilters, notFound: !quickFilters.notFound })"
+                >
+                    <template #prepend><v-icon class="chip-icon">mdi-help-circle-outline</v-icon></template>
+                    Not identified
+                </v-chip>
+            </v-col>
+
+            <v-col cols="12" md="" class="d-flex align-center justify-end ga-2">
+                <v-progress-circular
+                    v-if="isLoading"
+                    indeterminate
+                    size="18"
+                    width="2"
+                    color="primary"
+                />
+                <span class="text-caption text-medium-emphasis">
+                    {{ filteredTotal.toLocaleString() }} of {{ totalCount.toLocaleString() }} peptides
                 </span>
+            </v-col>
+        </v-row>
 
-                <span v-else>
-                    This peptide is not annotated with GO-terms.
-                </span>
-            </v-tooltip>
+        <!-- ── Data table ─────────────────────────────────────────────────────── -->
+        <v-data-table-server
+            mobile-breakpoint="md"
+            :headers="headers"
+            :items="shownItems"
+            :items-per-page="5"
+            :items-length="filteredTotal"
+            density="compact"
+            style="background-color: transparent"
+            @update:options="refresh"
+        >
+            <template #no-data>
+                <v-alert
+                    class="ma-3"
+                    density="compact"
+                    type="info"
+                    variant="tonal"
+                    text="No peptides found"
+                />
+            </template>
 
-            <v-tooltip v-if="item.faCounts" location="top">
-                <template #activator="{ props }">
-                    <v-avatar
-                        v-bind="props"
-                        size="30"
-                        :color="item.faCounts.ec > 0 ? 'indigo' : 'indigo-lighten-4'"
-                        class="me-1"
-                    >
-                        <span
-                            class="text-white"
-                            style="font-size: 14px !important;"
+            <template #item.peptide="{ item }">
+                <a
+                    class="cursor-pointer"
+                    @click="openPeptideAnalysis(item.peptide)"
+                    :style="$vuetify.display.mobile ? 'display: inline-block; max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;' : ''"
+                >
+                    {{ item.peptide }}
+                </a>
+            </template>
+
+            <template #item.faCounts="{ item }">
+                <v-tooltip v-if="item.faCounts" location="top">
+                    <template #activator="{ props }">
+                        <v-avatar
+                            v-bind="props"
+                            size="30"
+                            :color="item.faCounts.go > 0 ? 'amber' : 'amber-lighten-4'"
+                            class="me-1"
                         >
-                            EC
+                            <span
+                                :class="[ item.faCounts.go > 0 ? 'text-black' : 'text-grey', 'headline']"
+                                style="font-size: 14px !important;"
+                            >
+                                GO
+                            </span>
+                        </v-avatar>
+                    </template>
+
+                    <span v-if="item.faCounts.go > 0">
+                        This peptide is annotated with {{ item.faCounts.go }}
+                        <span class="font-weight-bold">
+                            {{ item.faCounts.go === 1 ? "GO-term" : "GO-terms" }}.
                         </span>
-                    </v-avatar>
-                </template>
-
-                <span v-if="item.faCounts.ec > 0">
-                    This peptide is annotated with {{ item.faCounts.ec }}
-                    <span class="font-weight-bold">
-                        {{ item.faCounts.ec === 1 ? "EC-number" : "EC-numbers" }}.
                     </span>
-                </span>
+                    <span v-else>This peptide is not annotated with GO-terms.</span>
+                </v-tooltip>
 
-                <span v-else>
-                    This peptide is not annotated with EC-numbers.
-                </span>
-            </v-tooltip>
-
-            <v-tooltip v-if="item.faCounts" location="top">
-                <template #activator="{ props }">
-                    <v-avatar
-                        v-bind="props"
-                        size="30"
-                        :color="item.faCounts.ipr > 0 ? 'red' : 'red-lighten-4'"
-                    >
-                        <span
-                            class="text-white"
-                            style="font-size: 14px !important;"
+                <v-tooltip v-if="item.faCounts" location="top">
+                    <template #activator="{ props }">
+                        <v-avatar
+                            v-bind="props"
+                            size="30"
+                            :color="item.faCounts.ec > 0 ? 'indigo' : 'indigo-lighten-4'"
+                            class="me-1"
                         >
-                            IPR
+                            <span class="text-white" style="font-size: 14px !important;">EC</span>
+                        </v-avatar>
+                    </template>
+
+                    <span v-if="item.faCounts.ec > 0">
+                        This peptide is annotated with {{ item.faCounts.ec }}
+                        <span class="font-weight-bold">
+                            {{ item.faCounts.ec === 1 ? "EC-number" : "EC-numbers" }}.
                         </span>
-                    </v-avatar>
-                </template>
-
-                <span v-if="item.faCounts.ipr > 0">
-                    This peptide is annotated with {{ item.faCounts.ipr }}
-                    <span class="font-weight-bold">
-                        {{ item.faCounts.ipr === 1 ? "InterPro-entry" : "InterPro-entries" }}.
                     </span>
-                </span>
+                    <span v-else>This peptide is not annotated with EC-numbers.</span>
+                </v-tooltip>
 
-                <span v-else>
-                    This protein is not annotated with InterPro-entries.
-                </span>
-            </v-tooltip>
-        </template>
+                <v-tooltip v-if="item.faCounts" location="top">
+                    <template #activator="{ props }">
+                        <v-avatar
+                            v-bind="props"
+                            size="30"
+                            :color="item.faCounts.ipr > 0 ? 'red' : 'red-lighten-4'"
+                        >
+                            <span class="text-white" style="font-size: 14px !important;">IPR</span>
+                        </v-avatar>
+                    </template>
 
-        <template #item.warning="{ item }">
-            <v-tooltip
-                v-if="!item.found"
-                text="This peptide was not found by Unipept"
-            >
-                <template #activator="{ props }">
-                    <v-icon
-                        v-if="!item.found"
-                        v-bind="props"
-                        color="warning"
-                        size="20"
-                        icon="mdi-alert-circle-outline"
-                    />
-                </template>
-            </v-tooltip>
-        </template>
-    </v-data-table-server>
+                    <span v-if="item.faCounts.ipr > 0">
+                        This peptide is annotated with {{ item.faCounts.ipr }}
+                        <span class="font-weight-bold">
+                            {{ item.faCounts.ipr === 1 ? "InterPro-entry" : "InterPro-entries" }}.
+                        </span>
+                    </span>
+                    <span v-else>This protein is not annotated with InterPro-entries.</span>
+                </v-tooltip>
+            </template>
+
+            <template #item.warning="{ item }">
+                <v-tooltip
+                    v-if="!item.found"
+                    text="This peptide was not found by Unipept"
+                >
+                    <template #activator="{ props }">
+                        <v-icon
+                            v-bind="props"
+                            color="warning"
+                            size="20"
+                            icon="mdi-alert-circle-outline"
+                        />
+                    </template>
+                </v-tooltip>
+            </template>
+        </v-data-table-server>
+    </div>
 </template>
 
 <script setup lang="ts">
-import {ref, watch} from "vue";
-import {SingleAnalysisStore} from "@/store/SingleAnalysisStore";
-import useOntologyStore from "@/store/OntologyStore";
+import { ref } from "vue";
+import { SingleAnalysisStore } from "@/store/SingleAnalysisStore";
+import { useTableSortFilter } from "@/composables/useTableSortFilter";
 
 const { analysis } = defineProps<{
     analysis: SingleAnalysisStore
 }>();
 
-const shownItems = ref<AnalysisSummaryTableItem[]>([]);
+const {
+    search,
+    quickFilters,
+    shownItems,
+    filteredTotal,
+    totalCount,
+    isLoading,
+    refresh,
+    onSearchInput,
+    onQuickFilterChange
+} = useTableSortFilter(analysis);
 
-const { getNcbiDefinition } = useOntologyStore();
+// ── Search hints dropdown ─────────────────────────────────────────────────────
 
-const computeShownItems = (params: ConfigParams) => {
-    let itemsPerPage = params.itemsPerPage;
-    // Check if we need to show all items
-    if (params.itemsPerPage === -1) {
-        itemsPerPage = analysis.peptidesTable!.totalCount;
-    }
-
-    shownItems.value = analysis.peptidesTable!
-        .getEntriesRange(
-            (params.page - 1) * itemsPerPage,
-            params.page * itemsPerPage
-        )
-        .map(([peptide, count]) => {
-            const lca = analysis.peptideToLca!.get(peptide)!;
-            return {
-                peptide: peptide,
-                occurrence: count,
-                lca: getNcbiDefinition(lca)?.name ?? "N/A",
-                rank: getNcbiDefinition(lca)?.rank ?? "N/A",
-                found: analysis.peptideToLca!.has(peptide),
-                faCounts: analysis.peptideToData!.get(peptide)?.faCounts
-            };
-        });
+interface SearchHint {
+    query:       string;
+    color?:      string;
+    description: string;
 }
 
-watch(() => analysis, () => computeShownItems({
-    page: 1,
-    itemsPerPage: 5,
-    sortBy: []
-}));
+const searchHints: SearchHint[] = [
+    { query: "sus scrofa",           color: "green",  description: "Free text — matched against the LCA name column" },
+    { query: "rank:species",         color: "blue",   description: "Filter by taxonomic rank" },
+    { query: "has:go",               color: "amber",  description: "Show only peptides with GO annotations" },
+    { query: "has:ec",               color: "indigo", description: "Show only peptides with EC numbers" },
+    { query: "lca:homo sapiens",     color: "teal",   description: "Multi-word LCA filter (supports partial match)" },
+    { query: "rank:species has:go",  color: undefined, description: "Combine multiple filters" },
+];
+
+const hintsOpen = ref(false);
+let blurTimeout: ReturnType<typeof setTimeout> | null = null;
+
+const onSearchFocus = () => {
+    if (blurTimeout) { clearTimeout(blurTimeout); blurTimeout = null; }
+    hintsOpen.value = !search.value;
+};
+
+const onSearchBlur = () => {
+    blurTimeout = setTimeout(() => { hintsOpen.value = false; }, 150);
+};
+
+const handleSearchInput = (value: string | null) => {
+    onSearchInput(value);
+    hintsOpen.value = !value;
+};
+
+const handleClear = () => {
+    onSearchInput("");
+    hintsOpen.value = true;
+};
+
+const applyHint = (query: string) => {
+    if (blurTimeout) { clearTimeout(blurTimeout); blurTimeout = null; }
+    onSearchInput(query);
+    hintsOpen.value = false;
+};
 </script>
 
 <script lang="ts">
@@ -214,38 +340,27 @@ const headers: DataTableHeader[] = [
         title: "Annotations",
         align: "start",
         key: "faCounts",
-        width: "15%"
+        width: "15%",
+        sortable: false
     },
     {
         title: "",
         align: "start",
         key: "warning",
-        width: "5%"
+        width: "5%",
+        sortable: false
     }
 ];
 
-export interface AnalysisSummaryTableItem {
-    peptide: string;
-    occurrence: number;
-    lca: string;
-    rank: string;
-    found: boolean;
-    faCounts: { all: number, ec: number, go: number, ipr: number } | undefined;
-}
-
-interface ConfigParams {
-    page: number;
-    itemsPerPage: number;
-    sortBy: { key: string, order: "asc" | "desc" }[];
-}
+export type { AnalysisSummaryTableItem } from "@/composables/useTableSortFilter";
 
 const openPeptideAnalysis = (peptide: string) => {
     // TODO: change this. Hardcoded link to website for testing purposes
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = `https://unipept.ugent.be/spa/${peptide}?equate=${true}`;
-    a.target = '_blank';
+    a.target = "_blank";
     a.click();
-}
+};
 </script>
 
 <style scoped>
@@ -256,5 +371,41 @@ a {
 
 a:hover {
     text-decoration: none;
+}
+
+/* Align prepend icons vertically with chip text */
+:deep(.chip-icon) {
+    font-size: 14px !important;
+    line-height: 1 !important;
+    align-self: center !important;
+    margin-inline-end: 4px;
+}
+
+/* Search hints dropdown */
+.hints-dropdown {
+    position: absolute;
+    top: calc(100% + 2px);
+    left: 0;
+    right: 0;
+    z-index: 2400;
+}
+
+.hints-header {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(0, 0, 0, 0.45);
+}
+
+.hint-item {
+    cursor: pointer;
+}
+
+.hint-query {
+    font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, monospace;
+    font-size: 13px;
+    min-width: 160px;
+    display: inline-block;
 }
 </style>

--- a/src/components/analysis/multi/AnalysisSummaryTable.vue
+++ b/src/components/analysis/multi/AnalysisSummaryTable.vue
@@ -18,7 +18,7 @@
                     clearable
                     prepend-inner-icon="mdi-magnify"
                     autocomplete="off"
-                    placeholder='Try “sus scrofa”, “rank:species”, or just “GO”…'
+                    placeholder='Try “sus scrofa”, “rank:species”, or just “has:GO”…'
                     @focus="onSearchFocus"
                     @blur="onSearchBlur"
                     @update:model-value="handleSearchInput"

--- a/src/components/analysis/multi/AnalysisSummaryTable.vue
+++ b/src/components/analysis/multi/AnalysisSummaryTable.vue
@@ -1,7 +1,14 @@
 <template>
     <div>
+
+
+        <!-- ── Search hint ────────────────────────────────────────────────────── -->
+        <p class="text-caption text-medium-emphasis mb-1">
+            Type freely or use <code>field:value</code>. Each term gets auto-classified — dashed chips show inferred fields you can confirm or reassign.
+        </p>
+
         <!-- ── Search bar with hints dropdown ─────────────────────────────────── -->
-        <v-row density="compact" class="mb-1 px-1">
+        <v-row density="compact">
             <v-col cols="12" style="position: relative;">
                 <v-text-field
                     :model-value="search"
@@ -49,7 +56,7 @@
         </v-row>
 
         <!-- ── Quick filters + peptide count ─────────────────────────────────── -->
-        <v-row density="compact" class="mb-2 px-1 align-center">
+        <v-row density="compact" class="mb-2 align-center">
             <v-col cols="12" md="auto" class="d-flex align-center flex-wrap ga-1">
                 <span class="text-caption text-medium-emphasis me-1">Quick filters:</span>
 

--- a/src/components/analysis/multi/AnalysisSummaryTable.vue
+++ b/src/components/analysis/multi/AnalysisSummaryTable.vue
@@ -249,7 +249,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { onBeforeUnmount, ref } from "vue";
 import { SingleAnalysisStore } from "@/store/SingleAnalysisStore";
 import { useTableSortFilter } from "@/composables/useTableSortFilter";
 
@@ -313,6 +313,10 @@ const applyHint = (query: string) => {
     onSearchInput(query);
     hintsOpen.value = false;
 };
+
+onBeforeUnmount(() => {
+    if (blurTimeout) clearTimeout(blurTimeout);
+});
 </script>
 
 <script lang="ts">

--- a/src/composables/processing/workers/tableSortFilter.worker.ts
+++ b/src/composables/processing/workers/tableSortFilter.worker.ts
@@ -1,0 +1,193 @@
+import { ShareableMap } from "shared-memory-datastructures";
+import type { AnalysisSummaryTableItem, TableSortFilterWorkerInput, TableSortFilterWorkerOutput } from "../../useTableSortFilter";
+import PeptideData from "@/logic/ontology/peptides/PeptideData";
+import PeptideDataSerializer from "@/logic/ontology/peptides/PeptideDataSerializer";
+
+self.onunhandledrejection = (event) => {
+    throw event.reason;
+};
+
+self.onmessage = (event) => {
+    self.postMessage(process(event.data));
+};
+
+// ─── Query parser ─────────────────────────────────────────────────────────────
+
+interface ParsedQuery {
+    freeText:   string;
+    rankFilter: string;
+    lcaFilter:  string;
+    hasGo:      boolean;
+    hasEc:      boolean;
+    hasIpr:     boolean;
+    hasAny:     boolean;
+}
+
+/**
+ * Parses a search string into structured filter parts.
+ *
+ * Supported syntax:
+ *   rank:species       — filter by taxonomic rank (substring match)
+ *   lca:sus scrofa     — filter by LCA name (multi-word, substring match)
+ *   has:go             — require GO annotations
+ *   has:ec             — require EC annotations
+ *   has:ipr            — require InterPro annotations
+ *   has:annotation(s)  — require any functional annotation
+ *
+ * Remaining tokens after extracting key:value pairs become freeText,
+ * which is matched as a substring against the peptide sequence.
+ */
+const parseQuery = (search: string): ParsedQuery => {
+    const result: ParsedQuery = {
+        freeText: "", rankFilter: "", lcaFilter: "",
+        hasGo: false, hasEc: false, hasIpr: false, hasAny: false
+    };
+
+    const trimmed = search.trim();
+    if (!trimmed) return result;
+
+    // Match key:value tokens where the value extends until the next key:value pair or end.
+    // The negative lookahead (?!\w+:) prevents consuming the start of the next key:value token.
+    const keyValueRe = /(\w+):((?:\S+)(?:\s+(?!\w+:)\S+)*)/g;
+    const freeTextParts: string[] = [];
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = keyValueRe.exec(trimmed)) !== null) {
+        const before = trimmed.slice(lastIndex, match.index).trim();
+        if (before) freeTextParts.push(before);
+        lastIndex = match.index + match[0].length;
+
+        const key   = match[1].toLowerCase();
+        const value = match[2].trim().toLowerCase();
+
+        switch (key) {
+            case "rank": result.rankFilter = value; break;
+            case "lca":  result.lcaFilter  = value; break;
+            case "has":
+                if (value === "go")                                  result.hasGo  = true;
+                else if (value === "ec")                             result.hasEc  = true;
+                else if (value === "ipr")                            result.hasIpr = true;
+                else if (value === "annotation" || value === "annotations") result.hasAny = true;
+                break;
+        }
+    }
+
+    const after = trimmed.slice(lastIndex).trim();
+    if (after) freeTextParts.push(after);
+
+    result.freeText = freeTextParts.join(" ").toLowerCase();
+    return result;
+};
+
+// ─── Main processing function ─────────────────────────────────────────────────
+
+const process = ({
+    peptideCountsTransferable,
+    peptideToDataTransferable,
+    peptideToLcaTransferable,
+    ncbiSubset,
+    search,
+    quickFilters,
+    sortKey,
+    sortOrder,
+    page,
+    itemsPerPage
+}: TableSortFilterWorkerInput): TableSortFilterWorkerOutput => {
+    const peptideCounts = ShareableMap.fromTransferableState<string, number>(
+        peptideCountsTransferable
+    );
+    const peptideToData = ShareableMap.fromTransferableState<string, PeptideData>(
+        peptideToDataTransferable,
+        { serializer: new PeptideDataSerializer() }
+    );
+    const peptideToLca = ShareableMap.fromTransferableState<string, number>(
+        peptideToLcaTransferable
+    );
+
+    const query = parseQuery(search);
+
+    const rows: TableSortFilterWorkerOutput["rows"] = [];
+
+    for (const [peptide, count] of peptideCounts.entries()) {
+        // ── Free-text filter (peptide sequence) ──────────────────────────────
+        if (query.freeText && !peptide.toLowerCase().includes(query.freeText)) {
+            continue;
+        }
+
+        const lcaId      = peptideToLca.get(peptide);
+        const ncbiEntry  = lcaId !== undefined ? ncbiSubset[lcaId] : undefined;
+        const peptideData = peptideToData.get(peptide);
+        const faCounts   = peptideData?.faCounts;
+
+        // ── LCA name filter ───────────────────────────────────────────────────
+        if (query.lcaFilter) {
+            const lcaName = ncbiEntry?.name.toLowerCase() ?? "";
+            if (!lcaName.includes(query.lcaFilter)) continue;
+        }
+
+        // ── Rank filter ───────────────────────────────────────────────────────
+        if (query.rankFilter) {
+            const rank = ncbiEntry?.rank.toLowerCase() ?? "";
+            if (!rank.includes(query.rankFilter)) continue;
+        }
+
+        // ── has: query filters ────────────────────────────────────────────────
+        if (query.hasGo  && (!faCounts || faCounts.go  === 0)) continue;
+        if (query.hasEc  && (!faCounts || faCounts.ec  === 0)) continue;
+        if (query.hasIpr && (!faCounts || faCounts.ipr === 0)) continue;
+        if (query.hasAny && (!faCounts || (faCounts.go === 0 && faCounts.ec === 0 && faCounts.ipr === 0))) continue;
+
+        // ── Quick filter chips ────────────────────────────────────────────────
+        if (quickFilters.speciesLevel && ncbiEntry?.rank !== "species") continue;
+        if (quickFilters.hasGo          && (!faCounts || faCounts.go  === 0)) continue;
+        if (quickFilters.hasEc          && (!faCounts || faCounts.ec  === 0)) continue;
+        if (quickFilters.hasIpr         && (!faCounts || faCounts.ipr === 0)) continue;
+        if (quickFilters.notFound       && lcaId !== undefined) continue;
+
+        rows.push({
+            peptide,
+            occurrence: count,
+            lca:   ncbiEntry?.name ?? "N/A",
+            rank:  ncbiEntry?.rank ?? "N/A",
+            found: lcaId !== undefined,
+            faCounts
+        });
+    }
+
+    // ── Sort ─────────────────────────────────────────────────────────────────
+    if (sortKey && sortOrder) {
+        const dir = sortOrder === "asc" ? 1 : -1;
+
+        rows.sort((a: AnalysisSummaryTableItem, b: AnalysisSummaryTableItem) => {
+            let valA: string | number;
+            let valB: string | number;
+
+            if (sortKey === "faCounts") {
+                valA = a.faCounts?.all ?? 0;
+                valB = b.faCounts?.all ?? 0;
+            } else {
+                valA = (a as Record<string, any>)[sortKey];
+                valB = (b as Record<string, any>)[sortKey];
+            }
+
+            if (typeof valA === "string") valA = valA.toLowerCase();
+            if (typeof valB === "string") valB = valB.toLowerCase();
+
+            if (valA < valB) return -dir;
+            if (valA > valB) return  dir;
+            return 0;
+        });
+    }
+
+    const totalCount = rows.length;
+
+    // ── Paginate ─────────────────────────────────────────────────────────────
+    const start = (page - 1) * itemsPerPage;
+    const end   = itemsPerPage === -1 ? totalCount : start + itemsPerPage;
+
+    return {
+        rows: rows.slice(start, end),
+        totalCount
+    };
+};

--- a/src/composables/processing/workers/tableSortFilter.worker.ts
+++ b/src/composables/processing/workers/tableSortFilter.worker.ts
@@ -110,15 +110,22 @@ const process = ({
     const rows: TableSortFilterWorkerOutput["rows"] = [];
 
     for (const [peptide, count] of peptideCounts.entries()) {
-        // ── Free-text filter (peptide sequence) ──────────────────────────────
-        if (query.freeText && !peptide.toLowerCase().includes(query.freeText)) {
-            continue;
+        const lcaId     = peptideToLca.get(peptide);
+        const ncbiEntry = lcaId !== undefined ? ncbiSubset[lcaId] : undefined;
+
+        // ── Free-text filter (peptide, LCA name, rank) ───────────────────────
+        if (query.freeText) {
+            const lcaName = ncbiEntry?.name.toLowerCase() ?? "";
+            const rank    = ncbiEntry?.rank.toLowerCase() ?? "";
+            if (
+                !peptide.toLowerCase().includes(query.freeText) &&
+                !lcaName.includes(query.freeText) &&
+                !rank.includes(query.freeText)
+            ) continue;
         }
 
-        const lcaId      = peptideToLca.get(peptide);
-        const ncbiEntry  = lcaId !== undefined ? ncbiSubset[lcaId] : undefined;
         const peptideData = peptideToData.get(peptide);
-        const faCounts   = peptideData?.faCounts;
+        const faCounts    = peptideData?.faCounts;
 
         // ── LCA name filter ───────────────────────────────────────────────────
         if (query.lcaFilter) {

--- a/src/composables/processing/workers/tableSortFilter.worker.ts
+++ b/src/composables/processing/workers/tableSortFilter.worker.ts
@@ -139,11 +139,9 @@ const process = ({
         if (query.hasAny && (!faCounts || (faCounts.go === 0 && faCounts.ec === 0 && faCounts.ipr === 0))) continue;
 
         // ── Quick filter chips ────────────────────────────────────────────────
+        // speciesLevel uses exact-match; rank:species in the search bar is substring-match
         if (quickFilters.speciesLevel && ncbiEntry?.rank !== "species") continue;
-        if (quickFilters.hasGo          && (!faCounts || faCounts.go  === 0)) continue;
-        if (quickFilters.hasEc          && (!faCounts || faCounts.ec  === 0)) continue;
-        if (quickFilters.hasIpr         && (!faCounts || faCounts.ipr === 0)) continue;
-        if (quickFilters.notFound       && lcaId !== undefined) continue;
+        if (quickFilters.notFound     && lcaId !== undefined) continue;
 
         rows.push({
             peptide,

--- a/src/composables/useTableSortFilter.ts
+++ b/src/composables/useTableSortFilter.ts
@@ -22,10 +22,10 @@ export interface NcbiSubsetEntry {
 }
 
 export interface QuickFilters {
-    speciesLevel: boolean;  // ncbiEntry.rank === "species"
-    hasGo:        boolean;  // go count > 0
-    hasEc:        boolean;  // ec count > 0
-    hasIpr:       boolean;  // ipr count > 0
+    speciesLevel: boolean;  // exact rank match — distinct from the rank: substring search
+    hasGo:        boolean;
+    hasEc:        boolean;
+    hasIpr:       boolean;
     notFound:     boolean;  // peptide not matched by Unipept
 }
 
@@ -50,6 +50,14 @@ export interface TableSortFilterWorkerOutput {
     rows:       AnalysisSummaryTableItem[];
     totalCount: number;
 }
+
+// Chip → query string mapping (chips without an entry are chip-only filters with no search equivalent)
+const CHIP_QUERIES: Partial<Record<keyof QuickFilters, string>> = {
+    speciesLevel: "rank:species",
+    hasGo:        "has:go",
+    hasEc:        "has:ec",
+    hasIpr:       "has:ipr",
+};
 
 // ─── Composable ───────────────────────────────────────────────────────────────
 
@@ -180,14 +188,6 @@ export function useTableSortFilter(analysis: SingleAnalysisStore) {
         search.value = value ?? "";
         page.value   = 1;
         scheduleWorker(300);
-    };
-
-    // Query strings that correspond to each chip (chips without an entry here are chip-only filters)
-    const CHIP_QUERIES: Partial<Record<keyof QuickFilters, string>> = {
-        speciesLevel: "rank:species",
-        hasGo:        "has:go",
-        hasEc:        "has:ec",
-        hasIpr:       "has:ipr",
     };
 
     /** Immediate handler for quick filter chip toggles */

--- a/src/composables/useTableSortFilter.ts
+++ b/src/composables/useTableSortFilter.ts
@@ -1,0 +1,232 @@
+import { computed, ref, toRaw, watch } from "vue";
+import { markRaw } from "vue";
+import { ShareableMap, TransferableState } from "shared-memory-datastructures";
+import type { SingleAnalysisStore } from "@/store/SingleAnalysisStore";
+import TableSortFilterWebWorker from "@/composables/processing/workers/tableSortFilter.worker.ts?worker&inline";
+import useAsyncWebWorker from "@/composables/useAsyncWebWorker";
+
+// ─── Shared types (also imported by the worker) ───────────────────────────────
+
+export interface AnalysisSummaryTableItem {
+    peptide:    string;
+    occurrence: number;
+    lca:        string;
+    rank:       string;
+    found:      boolean;
+    faCounts:   { all: number; ec: number; go: number; ipr: number } | undefined;
+}
+
+export interface NcbiSubsetEntry {
+    name: string;
+    rank: string;
+}
+
+export interface QuickFilters {
+    speciesLevel: boolean;  // ncbiEntry.rank === "species"
+    hasGo:        boolean;  // go count > 0
+    hasEc:        boolean;  // ec count > 0
+    hasIpr:       boolean;  // ipr count > 0
+    notFound:     boolean;  // peptide not matched by Unipept
+}
+
+export interface TableSortFilterWorkerInput {
+    /** TransferableState of peptidesTable.counts — zero-copy via SharedArrayBuffer */
+    peptideCountsTransferable:  TransferableState;
+    /** TransferableState of peptideToData — zero-copy via SharedArrayBuffer */
+    peptideToDataTransferable:  TransferableState;
+    /** TransferableState of a ShareableMap built once from the plain peptideToLca Map */
+    peptideToLcaTransferable:   TransferableState;
+    /** Tiny NCBI name/rank subset for unique LCA ids — structured-cloned (small) */
+    ncbiSubset:                 Record<number, NcbiSubsetEntry>;
+    search:       string;
+    quickFilters: QuickFilters;
+    sortKey:      string;
+    sortOrder:    "asc" | "desc" | "";
+    page:         number;
+    itemsPerPage: number;
+}
+
+export interface TableSortFilterWorkerOutput {
+    rows:       AnalysisSummaryTableItem[];
+    totalCount: number;
+}
+
+// ─── Composable ───────────────────────────────────────────────────────────────
+
+export function useTableSortFilter(analysis: SingleAnalysisStore) {
+    // ── Reactive filter / sort / pagination state (bound to UI controls) ──
+    const search       = ref("");
+    const quickFilters = ref<QuickFilters>({ speciesLevel: false, hasGo: false, hasEc: false, hasIpr: false, notFound: false });
+    const page         = ref(1);
+    const itemsPerPage = ref(5);
+    const sortKey      = ref("");
+    const sortOrder    = ref<"asc" | "desc" | "">("");
+
+    // ── Reactive output state ─────────────────────────────────────────────
+    const shownItems    = ref<AnalysisSummaryTableItem[]>([]);
+    const filteredTotal = ref(0);
+    const isLoading     = ref(false);
+
+    // ── Unfiltered total — cheap size read, no worker needed ─────────────
+    const totalCount = computed(() => analysis.peptidesTable?.counts.size ?? 0);
+
+    // ── Per-analysis caches (rebuilt whenever analysis data changes) ──────
+    let peptideToLcaShareable: ShareableMap<string, number> | null = null;
+    let ncbiSubset: Record<number, NcbiSubsetEntry> | null = null;
+
+    const { post } = useAsyncWebWorker<
+        TableSortFilterWorkerInput,
+        TableSortFilterWorkerOutput
+    >(() => new TableSortFilterWebWorker());
+
+    // ── Stale-result guard ────────────────────────────────────────────────
+    let currentRequestId = 0;
+
+    // ── Cache builder ─────────────────────────────────────────────────────
+    const buildCaches = () => {
+        const lcaMap = analysis.peptideToLca;
+        if (!lcaMap || !lcaMap.size) return;
+
+        const shareable = new ShareableMap<string, number>({ expectedSize: lcaMap.size });
+        for (const [peptide, lcaId] of lcaMap) {
+            shareable.set(peptide, lcaId);
+        }
+        peptideToLcaShareable = markRaw(shareable);
+
+        const { ncbiOntology } = analysis.ontologyStore;
+        const subset: Record<number, NcbiSubsetEntry> = {};
+        for (const lcaId of lcaMap.values()) {
+            if (!(lcaId in subset)) {
+                const entry = ncbiOntology.get(lcaId);
+                if (entry) {
+                    subset[lcaId] = { name: entry.name, rank: entry.rank };
+                }
+            }
+        }
+        ncbiSubset = subset;
+    };
+
+    // ── Worker invocation ─────────────────────────────────────────────────
+    const runWorker = async () => {
+        if (
+            !analysis.peptidesTable  ||
+            !analysis.peptideToData  ||
+            !peptideToLcaShareable   ||
+            !ncbiSubset
+        ) return;
+
+        const myId = ++currentRequestId;
+        isLoading.value = true;
+
+        try {
+            const result = await post({
+                peptideCountsTransferable: analysis.peptidesTable.counts.toTransferableState(),
+                peptideToDataTransferable: analysis.peptideToData.toTransferableState(),
+                peptideToLcaTransferable:  peptideToLcaShareable.toTransferableState(),
+                ncbiSubset: toRaw(ncbiSubset),
+                search:       search.value,
+                quickFilters: toRaw(quickFilters.value),
+                sortKey:      sortKey.value,
+                sortOrder:    sortOrder.value,
+                page:         page.value,
+                itemsPerPage: itemsPerPage.value
+            });
+
+            if (myId !== currentRequestId) return;
+
+            shownItems.value    = result.rows;
+            filteredTotal.value = result.totalCount;
+        } finally {
+            if (myId === currentRequestId) {
+                isLoading.value = false;
+            }
+        }
+    };
+
+    // ── Debounce helpers ──────────────────────────────────────────────────
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const scheduleWorker = (delayMs = 100) => {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(runWorker, delayMs);
+    };
+
+    // ── Public API ────────────────────────────────────────────────────────
+
+    /** Called by v-data-table-server's @update:options event */
+    const refresh = (params: {
+        page?:         number;
+        itemsPerPage?: number;
+        sortBy?:       { key: string; order: "asc" | "desc" }[];
+    }) => {
+        if (params.page         !== undefined) page.value         = params.page;
+        if (params.itemsPerPage !== undefined) itemsPerPage.value = params.itemsPerPage;
+
+        if (params.sortBy !== undefined) {
+            if (params.sortBy.length > 0) {
+                sortKey.value   = params.sortBy[0].key;
+                sortOrder.value = params.sortBy[0].order;
+            } else {
+                sortKey.value   = "";
+                sortOrder.value = "";
+            }
+        }
+
+        scheduleWorker();
+    };
+
+    /** Debounced (300 ms) handler for the search text field */
+    const onSearchInput = (value: string | null) => {
+        search.value = value ?? "";
+        page.value   = 1;
+        scheduleWorker(300);
+    };
+
+    // Query strings that correspond to each chip (chips without an entry here are chip-only filters)
+    const CHIP_QUERIES: Partial<Record<keyof QuickFilters, string>> = {
+        speciesLevel: "rank:species",
+        hasGo:        "has:go",
+        hasEc:        "has:ec",
+        hasIpr:       "has:ipr",
+    };
+
+    /** Immediate handler for quick filter chip toggles */
+    const onQuickFilterChange = (filters: QuickFilters) => {
+        quickFilters.value = filters;
+
+        // Rebuild the search bar from the set of active chip queries
+        search.value = (Object.entries(CHIP_QUERIES) as [keyof QuickFilters, string][])
+            .filter(([key]) => filters[key])
+            .map(([, query]) => query)
+            .join(" ");
+
+        page.value = 1;
+        scheduleWorker();
+    };
+
+    // ── React to new analysis data ────────────────────────────────────────
+    watch(
+        () => analysis.peptidesTable,
+        () => {
+            buildCaches();
+            page.value = 1;
+            scheduleWorker();
+        },
+        { immediate: true }
+    );
+
+    return {
+        // State bindings
+        search,
+        quickFilters,
+        shownItems,
+        filteredTotal,
+        totalCount,
+        isLoading,
+
+        // Event handlers
+        refresh,
+        onSearchInput,
+        onQuickFilterChange
+    };
+}


### PR DESCRIPTION
This PR implements filtering and searching functionality for the peptide summary table. It allows users to sort the table by clicking the column headers, and to filter by any of the column's content. Queries can be combined, and a free text search is also available. Provides a fix for #1829.

**Screenshot:**
<img width="1370" height="756" alt="image" src="https://github.com/user-attachments/assets/0eb735b7-c073-4a20-825d-cad6a987f5ba" />

<img width="1332" height="411" alt="image" src="https://github.com/user-attachments/assets/ad68b010-ef77-4d28-8137-accc1ef6d2cf" />
