### PR TITLE
Add cutoff_used flag to responses of API

### DIFF
--- a/src/components/pages/documentation/apidocs/APIPept2EcPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2EcPage.vue
@@ -113,6 +113,9 @@
                     <inline-code>peptide</inline-code>: the peptide that was searched for.
                 </li>
                 <li>
+                    <inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise.
+                </li>
+                <li>
                     <inline-code>total_protein_count</inline-code>: total amount of proteins matched with the given peptide.
                 </li>
                 <li>

--- a/src/components/pages/documentation/apidocs/APIPept2EcPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2EcPage.vue
@@ -106,14 +106,15 @@
         >
             A list of
             <initialism>JSON</initialism>
-            objects is returned. By default, each object contains the following information fields:
+            objects is returned. By default, each object contains the following information fields.
+            If a peptide matches more than 10,000 proteins, the response is truncated and <inline-code>cutoff_used</inline-code> is set to <inline-code>true</inline-code>.
 
             <ul class="my-3">
                 <li>
                     <inline-code>peptide</inline-code>: the peptide that was searched for.
                 </li>
                 <li>
-                    <inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise.
+                    <inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff (default: 10,000 proteins) and the response was truncated; <inline-code>false</inline-code> otherwise.
                 </li>
                 <li>
                     <inline-code>total_protein_count</inline-code>: total amount of proteins matched with the given peptide.

--- a/src/components/pages/documentation/apidocs/APIPept2FunctPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2FunctPage.vue
@@ -112,6 +112,7 @@
 
                 <ul class="my-3">
                     <li><inline-code>peptide</inline-code>: the peptide that was searched for.</li>
+                    <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise.</li>
                     <li><inline-code>total_protein_count</inline-code>: total amount of proteins matched with the given peptide.</li>
                     <li>
                         <inline-code>ec</inline-code>:

--- a/src/components/pages/documentation/apidocs/APIPept2FunctPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2FunctPage.vue
@@ -108,11 +108,12 @@
             large-title
         >
             <p class="mb-2">
-                A list of <initialism>JSON</initialism> objects is returned. By default, each object contains the following information fields:
+                A list of <initialism>JSON</initialism> objects is returned. By default, each object contains the following information fields.
+                If a peptide matches more than 10,000 proteins, the response is truncated and <inline-code>cutoff_used</inline-code> is set to <inline-code>true</inline-code>.
 
                 <ul class="my-3">
                     <li><inline-code>peptide</inline-code>: the peptide that was searched for.</li>
-                    <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise.</li>
+                    <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff (default: 10,000 proteins) and the response was truncated; <inline-code>false</inline-code> otherwise.</li>
                     <li><inline-code>total_protein_count</inline-code>: total amount of proteins matched with the given peptide.</li>
                     <li>
                         <inline-code>ec</inline-code>:

--- a/src/components/pages/documentation/apidocs/APIPept2GoPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2GoPage.vue
@@ -111,14 +111,15 @@
             large-title
         >
             <p class="mb-2">
-                A list of <initialism>JSON</initialism> objects is returned. By default, each object contains the following information fields:
+                A list of <initialism>JSON</initialism> objects is returned. By default, each object contains the following information fields.
+                If a peptide matches more than 10,000 proteins, the response is truncated and <inline-code>cutoff_used</inline-code> is set to <inline-code>true</inline-code>.
 
                 <ul class="my-3">
                     <li>
                         <inline-code>peptide</inline-code>: the peptide that was searched for.
                     </li>
                     <li>
-                        <inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise.
+                        <inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff (default: 10,000 proteins) and the response was truncated; <inline-code>false</inline-code> otherwise.
                     </li>
                     <li>
                         <inline-code>total_protein_count</inline-code>: total amount of proteins matched with the given peptide.

--- a/src/components/pages/documentation/apidocs/APIPept2GoPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2GoPage.vue
@@ -118,6 +118,9 @@
                         <inline-code>peptide</inline-code>: the peptide that was searched for.
                     </li>
                     <li>
+                        <inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise.
+                    </li>
+                    <li>
                         <inline-code>total_protein_count</inline-code>: total amount of proteins matched with the given peptide.
                     </li>
                     <li>

--- a/src/components/pages/documentation/apidocs/APIPept2InterproPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2InterproPage.vue
@@ -110,11 +110,12 @@
             class="mt-5"
             large-title
         >
-            A list of <initialism>JSON</initialism> objects is returned. By default, each object contains the following information fields:
+            A list of <initialism>JSON</initialism> objects is returned. By default, each object contains the following information fields.
+            If a peptide matches more than 10,000 proteins, the response is truncated and <inline-code>cutoff_used</inline-code> is set to <inline-code>true</inline-code>.
 
             <ul class="my-3">
                 <li><inline-code>peptide</inline-code>: the peptide that was searched for.</li>
-                <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise.</li>
+                <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff (default: 10,000 proteins) and the response was truncated; <inline-code>false</inline-code> otherwise.</li>
                 <li><inline-code>total_protein_count</inline-code>: total amount of proteins matched with the given peptide.</li>
                 <li>
                     <inline-code>ipr</inline-code>:

--- a/src/components/pages/documentation/apidocs/APIPept2InterproPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2InterproPage.vue
@@ -114,6 +114,7 @@
 
             <ul class="my-3">
                 <li><inline-code>peptide</inline-code>: the peptide that was searched for.</li>
+                <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise.</li>
                 <li><inline-code>total_protein_count</inline-code>: total amount of proteins matched with the given peptide.</li>
                 <li>
                     <inline-code>ipr</inline-code>:

--- a/src/components/pages/documentation/apidocs/APIPept2LcaPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2LcaPage.vue
@@ -124,6 +124,7 @@
 
             <ul class="my-3">
                 <li><inline-code>peptide</inline-code>: the peptide that was searched for</li>
+                <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise</li>
                 <li><inline-code>taxon_id</inline-code>: the <initialism>NCBI</initialism> taxon id of the taxonomic lowest common ancestor</li>
                 <li><inline-code>taxon_name</inline-code>: the name of the taxonomic lowest common ancestor</li>
                 <li><inline-code>taxon_rank</inline-code>: the taxonomic rank of the taxonomic lowest common ancestor</li>

--- a/src/components/pages/documentation/apidocs/APIPept2LcaPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2LcaPage.vue
@@ -120,11 +120,12 @@
             large-title
         >
             The taxonomic lowest common ancestors associated with the given peptides are returned as a list of <initialism>JSON</initialism> objects.
-            By default, each object contains the following information fields extracted from the UniProt entry and <initialism>NCBI</initialism> taxonomy:
+            By default, each object contains the following information fields extracted from the UniProt entry and <initialism>NCBI</initialism> taxonomy.
+            If a peptide matches more than 10,000 proteins, the response is truncated and <inline-code>cutoff_used</inline-code> is set to <inline-code>true</inline-code>.
 
             <ul class="my-3">
                 <li><inline-code>peptide</inline-code>: the peptide that was searched for</li>
-                <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise</li>
+                <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff (default: 10,000 proteins) and the response was truncated; <inline-code>false</inline-code> otherwise</li>
                 <li><inline-code>taxon_id</inline-code>: the <initialism>NCBI</initialism> taxon id of the taxonomic lowest common ancestor</li>
                 <li><inline-code>taxon_name</inline-code>: the name of the taxonomic lowest common ancestor</li>
                 <li><inline-code>taxon_rank</inline-code>: the taxonomic rank of the taxonomic lowest common ancestor</li>

--- a/src/components/pages/documentation/apidocs/APIPept2ProtPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2ProtPage.vue
@@ -128,6 +128,7 @@
 
                 <ul class="my-3">
                     <li><inline-code>peptide</inline-code>: the peptide that matched this record</li>
+                    <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise</li>
                     <li><inline-code>uniprot_id</inline-code>: the UniProt accession number of the matching record</li>
                     <li><inline-code>protein_name</inline-code>: the name of the protein of the matching record</li>
                     <li><inline-code>taxon_id</inline-code>: the NCBI taxon id of the organism associated with the matching record</li>

--- a/src/components/pages/documentation/apidocs/APIPept2ProtPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2ProtPage.vue
@@ -124,11 +124,12 @@
         >
             <v-card-text>
                 Matching UniProt entries are returned as a list of <initialism>JSON</initialism> objects. By default, each object contains the following information
-                fields extracted from the UniProt entry:
+                fields extracted from the UniProt entry.
+                If a peptide matches more than 10,000 proteins, the response is truncated and <inline-code>cutoff_used</inline-code> is set to <inline-code>true</inline-code>.
 
                 <ul class="my-3">
                     <li><inline-code>peptide</inline-code>: the peptide that matched this record</li>
-                    <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise</li>
+                    <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff (default: 10,000 proteins) and the response was truncated; <inline-code>false</inline-code> otherwise</li>
                     <li><inline-code>uniprot_id</inline-code>: the UniProt accession number of the matching record</li>
                     <li><inline-code>protein_name</inline-code>: the name of the protein of the matching record</li>
                     <li><inline-code>taxon_id</inline-code>: the NCBI taxon id of the organism associated with the matching record</li>

--- a/src/components/pages/documentation/apidocs/APIPept2TaxaPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2TaxaPage.vue
@@ -139,11 +139,12 @@
             large-title
         >
             The organisms associated with matching UniProt entries are returned as a list of <initialism>json</initialism> objects. By default, each object
-            contains the following information fields extracted from the UniProt entry and <initialism>NCBI</initialism> taxonomy:
+            contains the following information fields extracted from the UniProt entry and <initialism>NCBI</initialism> taxonomy.
+            If a peptide matches more than 10,000 proteins, the response is truncated and <inline-code>cutoff_used</inline-code> is set to <inline-code>true</inline-code>.
 
             <ul class="my-3">
                 <li><inline-code>peptide</inline-code>: the peptide that matched this record</li>
-                <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise</li>
+                <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff (default: 10,000 proteins) and the response was truncated; <inline-code>false</inline-code> otherwise</li>
                 <li><inline-code>taxon_id</inline-code>: the <initialism>NCBI</initialism> taxon id of the organism associated with the matching record</li>
                 <li><inline-code>taxon_name</inline-code>: the name of the organism associated with the matching record</li>
                 <li><inline-code>taxon_rank</inline-code>: the taxonomic rank of the organism associated with the matching record</li>

--- a/src/components/pages/documentation/apidocs/APIPept2TaxaPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2TaxaPage.vue
@@ -143,6 +143,7 @@
 
             <ul class="my-3">
                 <li><inline-code>peptide</inline-code>: the peptide that matched this record</li>
+                <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise</li>
                 <li><inline-code>taxon_id</inline-code>: the <initialism>NCBI</initialism> taxon id of the organism associated with the matching record</li>
                 <li><inline-code>taxon_name</inline-code>: the name of the organism associated with the matching record</li>
                 <li><inline-code>taxon_rank</inline-code>: the taxonomic rank of the organism associated with the matching record</li>

--- a/src/components/pages/documentation/apidocs/APIPeptInfoPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPeptInfoPage.vue
@@ -130,6 +130,7 @@
 
             <ul class="my-3">
                 <li><inline-code>peptide</inline-code>: the peptide that was searched for.</li>
+                <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise.</li>
                 <li><inline-code>total_protein_count</inline-code>: total amount of proteins matched with the given peptide.</li>
                 <li>
                     <inline-code>ec</inline-code>:

--- a/src/components/pages/documentation/apidocs/APIPeptInfoPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPeptInfoPage.vue
@@ -126,11 +126,12 @@
             class="mt-5"
             large-title
         >
-            A list of <initialism>JSON</initialism> objects is returned. By default, each object contains the following information fields:
+            A list of <initialism>JSON</initialism> objects is returned. By default, each object contains the following information fields.
+            If a peptide matches more than 10,000 proteins, the response is truncated and <inline-code>cutoff_used</inline-code> is set to <inline-code>true</inline-code>.
 
             <ul class="my-3">
                 <li><inline-code>peptide</inline-code>: the peptide that was searched for.</li>
-                <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff and the response was truncated; <inline-code>false</inline-code> otherwise.</li>
+                <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff (default: 10,000 proteins) and the response was truncated; <inline-code>false</inline-code> otherwise.</li>
                 <li><inline-code>total_protein_count</inline-code>: total amount of proteins matched with the given peptide.</li>
                 <li>
                     <inline-code>ec</inline-code>:


### PR DESCRIPTION
This PR adds documentation about the new `cutoff_used` flag that was added to the Unipept API in PR https://github.com/unipept/unipept-api/pull/93.