### PR TITLE
Report protein match overflow explicitely

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unipept",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/src/components/analysis/multi/AnalysisSummary.vue
+++ b/src/components/analysis/multi/AnalysisSummary.vue
@@ -22,6 +22,16 @@
                             </a> ({{ displayPercentage(analysis.peptideTrust.missedPeptides.length / analysis.peptideTrust.searchedPeptides) }}) could not be found.
                         </h1>
 
+                        <h1
+                            v-if="analysis.config.useCrap && analysis.peptideTrust.crapFilteredPeptides.length > 0"
+                            class="text-body-large"
+                        >
+                            <a @click="showCrapFilteredPeptides = true">
+                                {{ analysis.peptideTrust.crapFilteredPeptides.length }} peptides
+                            </a>
+                            ({{ displayPercentage(analysis.peptideTrust.crapFilteredPeptides.length / analysis.peptideTrust.searchedPeptides) }}) were removed by the cRAP filter.
+                        </h1>
+
                         <v-alert
                             v-if="latest === analysis.databaseVersion"
                             color="success"
@@ -154,6 +164,11 @@
             v-model="showMissingPeptides"
             :peptides="missedPeptides"
         />
+
+        <crap-filtered-peptides-dialog
+            v-model="showCrapFilteredPeptides"
+            :peptides="crapFilteredPeptides"
+        />
     </v-unipept-card>
 </template>
 
@@ -166,6 +181,7 @@ import AnalysisSummaryExport from "@/components/analysis/multi/AnalysisSummaryEx
 import useCsvDownload from "@/composables/useCsvDownload";
 import usePeptideExport from "@/composables/usePeptideExport";
 import MissingPeptidesDialog from "@/components/analysis/multi/MissingPeptidesDialog.vue";
+import CrapFilteredPeptidesDialog from "@/components/analysis/multi/CrapFilteredPeptidesDialog.vue";
 import useMetaData from "@/composables/communication/unipept/useMetaData";
 import {GroupAnalysisStore} from "@/store/GroupAnalysisStore";
 import UnipeptCommunicator from "@/logic/communicators/unipept/UnipeptCommunicator";
@@ -187,10 +203,12 @@ const emits = defineEmits<{
 }>();
 
 const showMissingPeptides = ref(false);
+const showCrapFilteredPeptides = ref(false);
 
 const databaseName = computed(() => customFilterStore.getFilterNameById(analysis.config.database) || "Invalid database");
 
 const missedPeptides = computed(() => analysis.peptideTrust!.missedPeptides);
+const crapFilteredPeptides = computed(() => analysis.peptideTrust!.crapFilteredPeptides);
 
 let peptideExportContent: string[][] = [];
 let exportDelimiter: string = "";

--- a/src/components/analysis/multi/AnalysisSummaryTable.vue
+++ b/src/components/analysis/multi/AnalysisSummaryTable.vue
@@ -21,13 +21,31 @@
         </template>
 
         <template #item.peptide="{ item }">
-            <a
-                class="cursor-pointer"
-                @click="openPeptideAnalysis(item.peptide)"
-                :style="$vuetify.display.mobile ? 'display: inline-block; max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;' : ''"
-            >
-                {{ item.peptide }}
-            </a>
+            <v-tooltip location="top" :text="item.peptide">
+                <template #activator="{ props }">
+                    <a
+                        v-bind="props"
+                        class="cursor-pointer"
+                        style="display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+                        @click="openPeptideAnalysis(item.peptide)"
+                    >
+                        {{ item.peptide }}
+                    </a>
+                </template>
+            </v-tooltip>
+        </template>
+
+        <template #item.lca="{ item }">
+            <v-tooltip location="top" :text="item.lca">
+                <template #activator="{ props }">
+                    <span
+                        v-bind="props"
+                        style="display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+                    >
+                        {{ item.lca }}
+                    </span>
+                </template>
+            </v-tooltip>
         </template>
 
         <template #item.faCounts="{ item }">
@@ -118,42 +136,66 @@
             </v-tooltip>
         </template>
 
-        <template #item.cutoff="{ item }">
-            <v-tooltip v-if="item.found" location="top">
+        <template #item.status="{ item }">
+            <v-tooltip location="top">
                 <template #activator="{ props }">
-                    <v-icon
+                    <v-avatar
                         v-bind="props"
-                        :color="item.cutoffUsed ? 'warning' : 'success'"
-                        size="20"
-                        :icon="item.cutoffUsed ? 'mdi-alert-circle-outline' : 'mdi-check-circle-outline'"
-                    />
+                        size="30"
+                        :color="item.found ? 'success' : 'green-lighten-4'"
+                        class="me-1"
+                    >
+                        <v-icon
+                            size="18"
+                            :class="item.found ? 'text-white' : 'text-grey'"
+                            :icon="item.found ? 'mdi-database' : 'mdi-database-alert'"
+                        />
+                    </v-avatar>
+                </template>
+                <span v-if="item.found">Peptide was found by Unipept.</span>
+                <span v-else>This peptide was not found by Unipept.</span>
+            </v-tooltip>
+
+            <v-tooltip location="top">
+                <template #activator="{ props }">
+                    <v-avatar
+                        v-bind="props"
+                        size="30"
+                        :color="item.cutoffUsed ? 'amber' : 'amber-lighten-4'"
+                        class="me-1"
+                    >
+                        <v-icon
+                            size="18"
+                            :class="item.cutoffUsed ? 'text-black' : 'text-grey'"
+                            :icon="item.cutoffUsed ? 'mdi-gauge-full' : 'mdi-gauge-low'"
+                        />
+                    </v-avatar>
                 </template>
                 <div style="max-width: 500px">
                     <span v-if="item.cutoffUsed">
                         The number of matching proteins exceeded the Unipept API limit of 10,000 entries.
-                        Results shown are based on a subset of all matching proteins and may not be fully representative.
+                        Results are based on a subset and may not be fully representative.
                     </span>
-                    <span v-else>
-                        All matching proteins were included in the analysis for this peptide.
-                    </span>
+                    <span v-else>All matching proteins were included in the analysis for this peptide.</span>
                 </div>
             </v-tooltip>
-        </template>
 
-        <template #item.warning="{ item }">
-            <v-tooltip
-                v-if="!item.found"
-                text="This peptide was not found by Unipept"
-            >
+            <v-tooltip location="top">
                 <template #activator="{ props }">
-                    <v-icon
-                        v-if="!item.found"
+                    <v-avatar
                         v-bind="props"
-                        color="warning"
-                        size="20"
-                        icon="mdi-alert-circle-outline"
-                    />
+                        size="30"
+                        :color="item.crapFiltered ? 'red' : 'red-lighten-4'"
+                    >
+                        <v-icon
+                            size="18"
+                            :class="item.crapFiltered ? 'text-white' : 'text-grey'"
+                            :icon="item.crapFiltered ? 'mdi-filter-minus' : 'mdi-filter'"
+                        />
+                    </v-avatar>
                 </template>
+                <span v-if="item.crapFiltered">This peptide was filtered out by the cRAP filter and excluded from the analysis.</span>
+                <span v-else>This peptide was not filtered by the cRAP filter.</span>
             </v-tooltip>
         </template>
     </v-data-table-server>
@@ -193,7 +235,8 @@ const computeShownItems = (params: ConfigParams) => {
                 rank: getNcbiDefinition(lca)?.rank ?? "N/A",
                 found: analysis.peptideToLca!.has(peptide),
                 faCounts: analysis.peptideToData!.get(peptide)?.faCounts,
-                cutoffUsed: analysis.peptideToData!.get(peptide)?.cutoffUsed ?? false
+                cutoffUsed: analysis.peptideToData!.get(peptide)?.cutoffUsed ?? false,
+                crapFiltered: analysis.peptideToData!.get(peptide)?.crapFiltered ?? false
             };
         });
 }
@@ -213,7 +256,9 @@ const headers: DataTableHeader[] = [
         title: "Peptide",
         align: "start",
         key: "peptide",
-        width: "25%"
+        width: "25%",
+        maxWidth: "25%",
+        cellProps: { style: "max-width: 0; overflow: hidden;" }
     },
     {
         title: "Occurrence",
@@ -225,7 +270,9 @@ const headers: DataTableHeader[] = [
         title: "Lowest common ancestor",
         align: "start",
         key: "lca",
-        width: "25%"
+        width: "25%",
+        maxWidth: "25%",
+        cellProps: { style: "max-width: 0; overflow: hidden;" }
     },
     {
         title: "Rank",
@@ -240,16 +287,10 @@ const headers: DataTableHeader[] = [
         width: "15%"
     },
     {
-        title: "Match completeness",
+        title: "Status",
         align: "center",
-        key: "cutoff",
-        width: "5%"
-    },
-    {
-        title: "",
-        align: "start",
-        key: "warning",
-        width: "5%"
+        key: "status",
+        width: "10%"
     }
 ];
 
@@ -261,6 +302,7 @@ export interface AnalysisSummaryTableItem {
     found: boolean;
     faCounts: { all: number, ec: number, go: number, ipr: number } | undefined;
     cutoffUsed: boolean;
+    crapFiltered: boolean;
 }
 
 interface ConfigParams {

--- a/src/components/analysis/multi/AnalysisSummaryTable.vue
+++ b/src/components/analysis/multi/AnalysisSummaryTable.vue
@@ -118,6 +118,28 @@
             </v-tooltip>
         </template>
 
+        <template #item.cutoff="{ item }">
+            <v-tooltip v-if="item.found" location="top">
+                <template #activator="{ props }">
+                    <v-icon
+                        v-bind="props"
+                        :color="item.cutoffUsed ? 'warning' : 'success'"
+                        size="20"
+                        :icon="item.cutoffUsed ? 'mdi-alert-circle-outline' : 'mdi-check-circle-outline'"
+                    />
+                </template>
+                <div style="max-width: 500px">
+                    <span v-if="item.cutoffUsed">
+                        The number of matching proteins exceeded the Unipept API limit of 10,000 entries.
+                        Results shown are based on a subset of all matching proteins and may not be fully representative.
+                    </span>
+                    <span v-else>
+                        All matching proteins were included in the analysis for this peptide.
+                    </span>
+                </div>
+            </v-tooltip>
+        </template>
+
         <template #item.warning="{ item }">
             <v-tooltip
                 v-if="!item.found"
@@ -170,7 +192,8 @@ const computeShownItems = (params: ConfigParams) => {
                 lca: getNcbiDefinition(lca)?.name ?? "N/A",
                 rank: getNcbiDefinition(lca)?.rank ?? "N/A",
                 found: analysis.peptideToLca!.has(peptide),
-                faCounts: analysis.peptideToData!.get(peptide)?.faCounts
+                faCounts: analysis.peptideToData!.get(peptide)?.faCounts,
+                cutoffUsed: analysis.peptideToData!.get(peptide)?.cutoffUsed ?? false
             };
         });
 }
@@ -202,7 +225,7 @@ const headers: DataTableHeader[] = [
         title: "Lowest common ancestor",
         align: "start",
         key: "lca",
-        width: "30%"
+        width: "25%"
     },
     {
         title: "Rank",
@@ -215,6 +238,12 @@ const headers: DataTableHeader[] = [
         align: "start",
         key: "faCounts",
         width: "15%"
+    },
+    {
+        title: "Match completeness",
+        align: "center",
+        key: "cutoff",
+        width: "5%"
     },
     {
         title: "",
@@ -231,6 +260,7 @@ export interface AnalysisSummaryTableItem {
     rank: string;
     found: boolean;
     faCounts: { all: number, ec: number, go: number, ipr: number } | undefined;
+    cutoffUsed: boolean;
 }
 
 interface ConfigParams {

--- a/src/components/analysis/multi/AnalysisSummaryTable.vue
+++ b/src/components/analysis/multi/AnalysisSummaryTable.vue
@@ -142,12 +142,13 @@
                     <v-avatar
                         v-bind="props"
                         size="30"
-                        :color="item.found ? 'success' : 'green-lighten-4'"
+                        color="transparent"
+                        :style="item.found ? 'border: 2px solid rgb(var(--v-theme-success));' : 'border: 2px solid #C8E6C9;'"
                         class="me-1"
                     >
                         <v-icon
                             size="18"
-                            :class="item.found ? 'text-white' : 'text-grey'"
+                            :class="item.found ? 'text-success' : 'text-green-lighten-4'"
                             :icon="item.found ? 'mdi-database' : 'mdi-database-alert'"
                         />
                     </v-avatar>
@@ -161,22 +162,22 @@
                     <v-avatar
                         v-bind="props"
                         size="30"
-                        :color="item.cutoffUsed ? 'amber' : 'amber-lighten-4'"
+                        color="transparent"
+                        :style="item.cutoffUsed ? 'border: 2px solid #FFC107;' : 'border: 2px solid #FFECB3;'"
                         class="me-1"
                     >
                         <v-icon
                             size="18"
-                            :class="item.cutoffUsed ? 'text-black' : 'text-grey'"
+                            :class="item.cutoffUsed ? 'text-amber' : 'text-amber-lighten-4'"
                             :icon="item.cutoffUsed ? 'mdi-gauge-full' : 'mdi-gauge-low'"
                         />
                     </v-avatar>
                 </template>
                 <div style="max-width: 500px">
                     <span v-if="item.cutoffUsed">
-                        The number of matching proteins exceeded the Unipept API limit of 10,000 entries.
-                        Results are based on a subset and may not be fully representative.
+                        Protein match cutoff exceeded for this peptide. Results are based on a subset of matching proteins and may not be fully representative.
                     </span>
-                    <span v-else>All matching proteins were included in the analysis for this peptide.</span>
+                    <span v-else>Protein match cutoff not exceeded for this peptide. All matching proteins were included for the analysis of this peptide.</span>
                 </div>
             </v-tooltip>
 
@@ -185,11 +186,12 @@
                     <v-avatar
                         v-bind="props"
                         size="30"
-                        :color="item.crapFiltered ? 'red' : 'red-lighten-4'"
+                        color="transparent"
+                        :style="item.crapFiltered ? 'border: 2px solid #F44336;' : 'border: 2px solid #FFCDD2;'"
                     >
                         <v-icon
                             size="18"
-                            :class="item.crapFiltered ? 'text-white' : 'text-grey'"
+                            :class="item.crapFiltered ? 'text-red' : 'text-red-lighten-4'"
                             :icon="item.crapFiltered ? 'mdi-filter-minus' : 'mdi-filter'"
                         />
                     </v-avatar>

--- a/src/components/analysis/multi/CrapFilteredPeptidesDialog.vue
+++ b/src/components/analysis/multi/CrapFilteredPeptidesDialog.vue
@@ -74,6 +74,6 @@ const copyToClipboard = () => {
 
 <script lang="ts">
 const headers = [
-    { text: 'Peptide', value: 'name', width: '100%' }
+    { title: 'Peptide', value: 'name', width: '100%' }
 ];
 </script>

--- a/src/components/analysis/multi/CrapFilteredPeptidesDialog.vue
+++ b/src/components/analysis/multi/CrapFilteredPeptidesDialog.vue
@@ -1,0 +1,79 @@
+<template>
+    <v-dialog
+        v-model="dialogOpen"
+        width="50%"
+    >
+        <v-unipept-card>
+            <v-card-title class="d-flex align-center">
+                <h2>{{ peptides.length }} cRAP-filtered peptides</h2>
+                <v-spacer />
+                <v-btn
+                    icon="mdi-close"
+                    variant="plain"
+                    density="compact"
+                    @click="dialogOpen = false"
+                />
+            </v-card-title>
+
+            <v-card-text>
+                <v-alert
+                    color="warning"
+                    variant="tonal"
+                    icon="mdi-filter-outline"
+                    class="mb-4"
+                >
+                    These <b>{{ peptides.length }}</b> peptides match proteins in the
+                    <a href="https://www.thegpm.org/crap/" target="_blank">cRAP database</a>
+                    (Common Repository of Adventitious Proteins) and were excluded from the
+                    analysis. cRAP proteins are common laboratory contaminants such as keratins,
+                    trypsin, and BSA. Their presence in your sample is typically not biologically
+                    meaningful.
+                </v-alert>
+
+                <v-data-table-virtual
+                    v-if="peptides.length > 0"
+                    :headers="headers"
+                    :items="peptideItems"
+                    height="400"
+                    item-value="name"
+                    density="compact"
+                    hide-default-header
+                >
+                    <template #bottom>
+                        <v-btn
+                            class="mt-3"
+                            color="primary"
+                            variant="tonal"
+                            prepend-icon="mdi-content-copy"
+                            @click="copyToClipboard"
+                        >
+                            Copy to clipboard
+                        </v-btn>
+                    </template>
+                </v-data-table-virtual>
+            </v-card-text>
+        </v-unipept-card>
+    </v-dialog>
+</template>
+
+<script setup lang="ts">
+import {computed} from "vue";
+
+const dialogOpen = defineModel<boolean>();
+
+const { peptides } = defineProps<{
+    peptides: string[]
+}>();
+
+const peptideItems = computed(() => peptides.map(name => ({ name })));
+
+const copyToClipboard = () => {
+    navigator.clipboard.writeText(peptides.join('\n'));
+};
+</script>
+
+<script lang="ts">
+const headers = [
+    { text: 'Peptide', value: 'name', width: '100%' }
+];
+</script>

--- a/src/components/analysis/multi/MissingPeptidesDialog.vue
+++ b/src/components/analysis/multi/MissingPeptidesDialog.vue
@@ -5,7 +5,7 @@
     >
         <v-unipept-card>
             <v-card-title class="d-flex align-center">
-                <h1>{{ peptides.length }} missed peptides</h1>
+                <h2>{{ peptides.length }} missed peptides</h2>
                 <v-spacer />
                 <div class="justify-end">
                     <v-btn

--- a/src/components/analysis/multi/RecentAnalysisCard.vue
+++ b/src/components/analysis/multi/RecentAnalysisCard.vue
@@ -26,6 +26,7 @@
 
             <div v-if="loading" class="d-flex flex-column justify-center align-center h-100">
                 <v-progress-circular color="primary" indeterminate />
+                <p v-if="loadingMessage" class="mt-3 text-body-2 text-medium-emphasis">{{ loadingMessage }}</p>
             </div>
 
             <div v-else-if="projects.length > 0">
@@ -181,7 +182,8 @@ const props = defineProps<{
     height: number,
     projects: { name: string, totalPeptides: number, lastAccessed: Date }[],
     loading: boolean,
-    disabled: boolean
+    disabled: boolean,
+    loadingMessage?: string
 }>();
 
 const emits = defineEmits<{

--- a/src/components/analysis/multi/RecentAnalysisCard.vue
+++ b/src/components/analysis/multi/RecentAnalysisCard.vue
@@ -54,6 +54,23 @@
 
                                 <v-spacer />
 
+                                <v-tooltip
+                                    v-if="item.upgradeError"
+                                    :text="item.upgradeError"
+                                    max-width="320"
+                                >
+                                    <template #activator="{ props }">
+                                        <v-btn
+                                            v-bind="props"
+                                            variant="text"
+                                            color="warning"
+                                            icon="mdi-alert"
+                                            size="small"
+                                            @click.stop
+                                        />
+                                    </template>
+                                </v-tooltip>
+
                                 <v-btn
                                     variant="text"
                                     class="me-2"
@@ -180,7 +197,7 @@ import UploadProjectButton from "@/components/analysis/multi/UploadProjectButton
 
 const props = defineProps<{
     height: number,
-    projects: { name: string, totalPeptides: number, lastAccessed: Date }[],
+    projects: { name: string, totalPeptides: number, lastAccessed: Date, upgradeError?: string | null }[],
     loading: boolean,
     disabled: boolean,
     loadingMessage?: string

--- a/src/components/pages/features/analysis/MetaproteomeHomePage.vue
+++ b/src/components/pages/features/analysis/MetaproteomeHomePage.vue
@@ -1,5 +1,17 @@
 <template>
     <v-container>
+        <v-snackbar
+            v-model="showUpgradeError"
+            color="error"
+            :timeout="-1"
+            multi-line
+        >
+            {{ upgradeError }}
+            <template #actions>
+                <v-btn variant="text" @click="showUpgradeError = false">Dismiss</v-btn>
+            </template>
+        </v-snackbar>
+
         <v-row>
             <v-col cols="12" md="6">
                 <div ref="firstColumn">
@@ -55,13 +67,14 @@ import useUnipeptAnalysisStore from "@/store/UnipeptAnalysisStore";
 import NewAnalysisCard from "@/components/analysis/multi/NewAnalysisCard.vue";
 import RecentAnalysisCard from "@/components/analysis/multi/RecentAnalysisCard.vue";
 import {useElementBounding} from "@vueuse/core";
+import {storeToRefs} from "pinia";
 
 const router = useRouter();
 
+const store = useUnipeptAnalysisStore();
+const { importStatus } = storeToRefs(store);
 const {
     project,
-    importStatus,
-
     getProjects,
     loadNewProject,
     loadProjectFromStorage,
@@ -69,7 +82,7 @@ const {
     loadProjectFromSample,
     loadProjectFromPeptides,
     deleteProject
-} = useUnipeptAnalysisStore();
+} = store;
 const sampleDataStore = useSampleDataStore();
 
 const firstColumn = useTemplateRef("firstColumn");
@@ -82,7 +95,10 @@ const loadingSampleData: Ref<boolean> = ref(true);
 const loadingProject: Ref<boolean> = ref(false);
 const loadingDemoProject: Ref<boolean> = ref(false);
 
-const projects = ref<{ name: string, totalPeptides: number, lastAccessed: Date }[]>([]);
+const upgradeError: Ref<string | null> = ref(null);
+const showUpgradeError = ref(false);
+
+const projects = ref<{ name: string, totalPeptides: number, lastAccessed: Date, upgradeError?: string | null }[]>([]);
 
 const quickAnalyze = async (rawPeptides: string, config: AnalysisConfig) => {
     await loadProjectFromPeptides(rawPeptides, config);
@@ -92,18 +108,35 @@ const quickAnalyze = async (rawPeptides: string, config: AnalysisConfig) => {
 
 const importProject = async (projectName: string, file: File) => {
     loadingProject.value = true;
-    await loadProjectFromFile(projectName, file)
-    await router.push({ name: "mpaSingle" });
-    await startImport();
-    loadingProject.value = false;
+    try {
+        await loadProjectFromFile(projectName, file);
+        await router.push({ name: "mpaSingle" });
+        await startImport();
+    } catch (e) {
+        upgradeError.value = (e instanceof Error && e.message)
+            ? e.message
+            : "Failed to open this project. If it requires an upgrade, please check your internet connection and try again.";
+        showUpgradeError.value = true;
+    } finally {
+        loadingProject.value = false;
+    }
 }
 
 const loadFromIndexedDB = async (projectName: string) => {
     loadingProject.value = true;
-    await loadProjectFromStorage(projectName);
-    await router.push({ name: "mpaSingle" });
-    await startImport();
-    loadingProject.value = false;
+    try {
+        await loadProjectFromStorage(projectName);
+        await router.push({ name: "mpaSingle" });
+        await startImport();
+    } catch (e) {
+        upgradeError.value = (e instanceof Error && e.message)
+            ? e.message
+            : "Failed to open this project. If it requires an upgrade, please check your internet connection and try again.";
+        showUpgradeError.value = true;
+        projects.value = await getProjects();
+    } finally {
+        loadingProject.value = false;
+    }
 }
 
 const deleteFromIndexedDB = async (projectName: string) => {

--- a/src/components/pages/features/analysis/MetaproteomeHomePage.vue
+++ b/src/components/pages/features/analysis/MetaproteomeHomePage.vue
@@ -33,6 +33,7 @@
                     :projects="projects"
                     :disabled="loadingProject || loadingDemoProject"
                     :loading="loadingProject"
+                    :loading-message="importStatus"
                     @open="loadFromIndexedDB"
                     @upload="importProject"
                     @delete="deleteFromIndexedDB"
@@ -59,6 +60,7 @@ const router = useRouter();
 
 const {
     project,
+    importStatus,
 
     getProjects,
     loadNewProject,

--- a/src/components/results/SinglePeptideSummary.vue
+++ b/src/components/results/SinglePeptideSummary.vue
@@ -25,6 +25,17 @@
                 Equate I/L is disabled.
             </span>
         </div>
+        <v-alert
+            v-if="cutoffUsed"
+            type="warning"
+            variant="tonal"
+            class="my-3"
+            icon="mdi-alert-circle-outline"
+        >
+            The number of matching proteins for this peptide exceeds the Unipept API limit of 10,000 entries.
+            Biodiversity and functional annotation results are based on a subset of all matching proteins
+            and may not be fully representative.
+        </v-alert>
         <v-row>
             <v-col :cols="12" md="6">
                 <div class="headline">
@@ -167,6 +178,10 @@ const { displayPercentage } = usePercentage();
 const lcaDefinition = computed(() => {
     return getNcbiDefinition(props.assay.lca)
 });
+
+const cutoffUsed = computed(() =>
+    props.assay.peptideToData?.get(props.assay.peptide)?.cutoffUsed ?? false
+);
 
 const taxonomyUrl = (taxon: NcbiTaxon | undefined): string => {
     if (taxon === undefined || taxon.id === 1) {

--- a/src/composables/communication/unipept/pept2filtered.worker.ts
+++ b/src/composables/communication/unipept/pept2filtered.worker.ts
@@ -24,6 +24,7 @@ const process = async ({
     parallelRequests
 }: Pept2filteredData) => {
     const result = new ShareableMap<string, PeptideData>({ serializer: new PeptideDataSerializer() });
+    const crapFilteredPeptides: string[] = [];
 
     const requests: (() => Promise<void>)[] = [];
     for (let i = 0; i < peptides.length; i += batchSize) {
@@ -33,7 +34,6 @@ const process = async ({
                 body: JSON.stringify({
                     peptides: peptides.slice(i, i + batchSize),
                     equate_il: equate,
-                    blacklist_crap: useCrap,
                     report_taxa: true,
                     ...constructFilterJson(filter)
                 }),
@@ -41,6 +41,10 @@ const process = async ({
             }).then(r => r.json());
 
             for (const peptide of response.peptides) {
+                if (useCrap && peptide.crap_filtered) {
+                    crapFilteredPeptides.push(peptide.sequence);
+                    continue;
+                }
                 result.set(peptide.sequence, PeptideData.createFromPeptideDataResponse(peptide));
             }
         });
@@ -49,7 +53,8 @@ const process = async ({
     await runParallel(requests, parallelRequests);
 
     return {
-        peptToDataTransferable: result.toTransferableState()
+        peptToDataTransferable: result.toTransferableState(),
+        crapFilteredPeptides
     };
 }
 

--- a/src/composables/communication/unipept/usePept2filtered.ts
+++ b/src/composables/communication/unipept/usePept2filtered.ts
@@ -19,6 +19,7 @@ export interface Pept2filteredData {
 
 export interface Pept2filteredWorkerOutput {
     peptToDataTransferable: TransferableState;
+    crapFilteredPeptides: string[];
 }
 
 export default function usePept2filtered(
@@ -27,6 +28,7 @@ export default function usePept2filtered(
     parallelRequests = 5,
 ) {
     const peptideData = shallowRef<ShareableMap<string, PeptideData>>();
+    const crapFilteredPeptides = shallowRef<string[]>([]);
 
     const { post } = useAsyncWebWorker<Pept2filteredData, Pept2filteredWorkerOutput>(
         () => new Pept2filteredWebWorker()
@@ -38,7 +40,7 @@ export default function usePept2filtered(
         useCrap: boolean,
         filter: Filter | undefined
     ) => {
-        const { peptToDataTransferable } = await post({
+        const { peptToDataTransferable, crapFilteredPeptides: filtered } = await post({
             peptides,
             equate,
             useCrap,
@@ -49,10 +51,12 @@ export default function usePept2filtered(
         });
 
         peptideData.value = markRaw(ShareableMap.fromTransferableState<string, PeptideData>(peptToDataTransferable, { serializer: new PeptideDataSerializer() }));
+        crapFilteredPeptides.value = filtered;
     }
 
     return {
         peptideData,
+        crapFilteredPeptides,
 
         process
     }

--- a/src/composables/processing/peptide/usePeptideTrustProcessor.ts
+++ b/src/composables/processing/peptide/usePeptideTrustProcessor.ts
@@ -19,11 +19,10 @@ export default function usePeptideTrustProcessor() {
         for (const peptide of countTable.counts.keys()) {
             if (peptideData.has(peptide)) {
                 matchedPeptides += countTable.getOrDefault(peptide);
-            } else if (crapSet.has(peptide)) {
-                // peptide was found but excluded by CRAP blacklist filtering
-            } else {
+            } else if (!crapSet.has(peptide)) {
                 missedPeptides.push(peptide);
             }
+            // In all other cases, the peptide was found but excluded by CRAP blacklist filtering
         }
 
         trust.value = markRaw({

--- a/src/composables/processing/peptide/usePeptideTrustProcessor.ts
+++ b/src/composables/processing/peptide/usePeptideTrustProcessor.ts
@@ -9,14 +9,18 @@ export default function usePeptideTrustProcessor() {
 
     const process = (
         countTable: CountTable<string>,
-        peptideData: ShareableMap<string, PeptideData>
+        peptideData: ShareableMap<string, PeptideData>,
+        crapFilteredPeptides: string[] = []
     ): void => {
         let matchedPeptides = 0;
         const missedPeptides: string[] = [];
+        const crapSet = new Set(crapFilteredPeptides);
 
         for (const peptide of countTable.counts.keys()) {
             if (peptideData.has(peptide)) {
                 matchedPeptides += countTable.getOrDefault(peptide);
+            } else if (crapSet.has(peptide)) {
+                // peptide was found but excluded by CRAP blacklist filtering
             } else {
                 missedPeptides.push(peptide);
             }
@@ -24,6 +28,7 @@ export default function usePeptideTrustProcessor() {
 
         trust.value = markRaw({
             missedPeptides,
+            crapFilteredPeptides,
             matchedPeptides,
             searchedPeptides: countTable.totalCount
         });

--- a/src/composables/useProjectImport.ts
+++ b/src/composables/useProjectImport.ts
@@ -14,7 +14,8 @@ export interface SerializedStateData {
 
 type WorkerMessage =
     | { type: "status"; message: string }
-    | { type: "done"; data: SerializedStateData };
+    | { type: "done"; data: SerializedStateData }
+    | { type: "error"; message: string };
 
 export default function useProjectImport() {
     const status: Ref<string> = ref("");
@@ -26,6 +27,12 @@ export default function useProjectImport() {
             worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
                 if (event.data.type === "status") {
                     status.value = event.data.message;
+                } else if (event.data.type === "error") {
+                    worker.terminate();
+                    status.value = "";
+                    reject(new Error(
+                        event.data.message || "An unexpected error occurred while loading this project. Try again later."
+                    ));
                 } else {
                     worker.terminate();
                     status.value = "";
@@ -36,7 +43,9 @@ export default function useProjectImport() {
             worker.onerror = (error) => {
                 worker.terminate();
                 status.value = "";
-                reject(error.message);
+                reject(new Error(
+                    error.message || "An unexpected error occurred while loading this project. Try again later."
+                ));
             };
 
             worker.postMessage({ input });

--- a/src/composables/useProjectImport.ts
+++ b/src/composables/useProjectImport.ts
@@ -1,7 +1,7 @@
 import {ProjectAnalysisStoreImport} from "@/store/ProjectAnalysisStore";
-import useAsyncWebWorker from "@/composables/useAsyncWebWorker";
 import ProjectImportWorker from "./workers/projectImportWorker.worker?worker&inline";
 import {AppStateStoreImport} from "@/store/AppStateStore";
+import {ref, type Ref} from "vue";
 
 export interface ProjectImportData {
     input: File | Blob
@@ -12,16 +12,39 @@ export interface SerializedStateData {
     appState: AppStateStoreImport;
 }
 
+type WorkerMessage =
+    | { type: "status"; message: string }
+    | { type: "done"; data: SerializedStateData };
+
 export default function useProjectImport() {
-    const { post } = useAsyncWebWorker<ProjectImportData, SerializedStateData>(
-        () => new ProjectImportWorker()
-    );
+    const status: Ref<string> = ref("");
 
     const process = async (input: File | Blob): Promise<SerializedStateData> => {
-        return await post({ input })
-    }
+        const worker = new ProjectImportWorker();
+
+        return new Promise((resolve, reject) => {
+            worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
+                if (event.data.type === "status") {
+                    status.value = event.data.message;
+                } else {
+                    worker.terminate();
+                    status.value = "";
+                    resolve(event.data.data);
+                }
+            };
+
+            worker.onerror = (error) => {
+                worker.terminate();
+                status.value = "";
+                reject(error.message);
+            };
+
+            worker.postMessage({ input });
+        });
+    };
 
     return {
-        process
+        process,
+        status
     };
 }

--- a/src/composables/workers/projectImportWorker.worker.ts
+++ b/src/composables/workers/projectImportWorker.worker.ts
@@ -6,13 +6,12 @@ import {ProjectAnalysisStoreImport} from "@/store/ProjectAnalysisStore";
 import {TransferableState} from "shared-memory-datastructures";
 import {ArrayBufferUtils} from "@/logic/utils/ArrayBufferUtils";
 
-self.onunhandledrejection = (event) => {
-    // This will propagate to the main thread's `onerror` handler
-    throw event.reason;
-};
-
 self.onmessage = async (event) => {
-    self.postMessage({ type: "done", data: await process(event.data) });
+    try {
+        self.postMessage({ type: "done", data: await process(event.data) });
+    } catch (e) {
+        self.postMessage({ type: "error", message: (e as Error).message ?? String(e) });
+    }
 }
 
 const process = async({ input }: ProjectImportData): Promise<SerializedStateData> => {

--- a/src/composables/workers/projectImportWorker.worker.ts
+++ b/src/composables/workers/projectImportWorker.worker.ts
@@ -12,7 +12,7 @@ self.onunhandledrejection = (event) => {
 };
 
 self.onmessage = async (event) => {
-    self.postMessage(await process(event.data));
+    self.postMessage({ type: "done", data: await process(event.data) });
 }
 
 const process = async({ input }: ProjectImportData): Promise<SerializedStateData> => {
@@ -20,6 +20,10 @@ const process = async({ input }: ProjectImportData): Promise<SerializedStateData
 
     // If the user is trying to import an older Unipept project, we need to upgrade it here.
     const projectUpgradeManager = new ProjectUpgradeManager();
+    const needsUpgrade = await projectUpgradeManager.needsUpgrade(zipper);
+    if (needsUpgrade) {
+        self.postMessage({ type: "status", message: "Upgrading project format. This may take a moment..." });
+    }
     zipper = await projectUpgradeManager.upgradeIfNeeded(zipper);
 
     const metadataFile = zipper.file("metadata.json");

--- a/src/logic/Constants.ts
+++ b/src/logic/Constants.ts
@@ -1,4 +1,5 @@
-export const DEFAULT_API_BASE_URL = "https://api.unipept.ugent.be";
+// export const DEFAULT_API_BASE_URL = "https://api.unipept.ugent.be";
+export const DEFAULT_API_BASE_URL = "http://localhost:52212";
 export const DEFAULT_PATHWAY_PILOT_BASE_URL = "https://pathwaypilot.ugent.be/api";
 export const DEFAULT_ONTOLOGY_BATCH_SIZE = 100;
 export const DEFAULT_BATCH_SIZE = 200;

--- a/src/logic/Constants.ts
+++ b/src/logic/Constants.ts
@@ -1,5 +1,4 @@
-// export const DEFAULT_API_BASE_URL = "https://api.unipept.ugent.be";
-export const DEFAULT_API_BASE_URL = "http://localhost:52212";
+export const DEFAULT_API_BASE_URL = "https://api.unipept.ugent.be";
 export const DEFAULT_PATHWAY_PILOT_BASE_URL = "https://pathwaypilot.ugent.be/api";
 export const DEFAULT_ONTOLOGY_BATCH_SIZE = 100;
 export const DEFAULT_BATCH_SIZE = 200;

--- a/src/logic/ontology/peptides/PeptideData.spec.ts
+++ b/src/logic/ontology/peptides/PeptideData.spec.ts
@@ -16,7 +16,8 @@ describe("PeptideData", () => {
                 },
                 data: {"EC:1.2.3.5": 2, "GO:0000001": 35, "IPR:IPR000121": 18}
             },
-            taxa: [17, 45, 23]
+            taxa: [17, 45, 23],
+            cutoff_used: true
         };
 
         const peptideData = PeptideData.createFromPeptideDataResponse(response);
@@ -32,6 +33,7 @@ describe("PeptideData", () => {
         expect(peptideData.ipr["IPR:IPR000121"]).toBe(18);
         expect(peptideData.taxa[0]).toBe(17);
         expect(peptideData.taxa[1]).toBe(45);
+        expect(peptideData.cutoffUsed).toBe(true);
     });
 
     it("should correctly serialize and deserialize data", () => {
@@ -47,7 +49,8 @@ describe("PeptideData", () => {
                 },
                 data: {"EC:1.2.3.5": 2, "GO:0000001": 35, "IPR:IPR000121": 18}
             },
-            taxa: [59, 47, 78]
+            taxa: [59, 47, 78],
+            cutoff_used: false
         };
 
         const peptideData = PeptideData.createFromPeptideDataResponse(response);
@@ -56,5 +59,6 @@ describe("PeptideData", () => {
         expect(deserializedData.lca).toBe(peptideData.lca);
         expect(deserializedData.lineage).toEqual(peptideData.lineage);
         expect(deserializedData.faCounts).toEqual(peptideData.faCounts);
+        expect(deserializedData.cutoffUsed).toBe(false);
     });
 });

--- a/src/logic/ontology/peptides/PeptideData.spec.ts
+++ b/src/logic/ontology/peptides/PeptideData.spec.ts
@@ -17,7 +17,8 @@ describe("PeptideData", () => {
                 data: {"EC:1.2.3.5": 2, "GO:0000001": 35, "IPR:IPR000121": 18}
             },
             taxa: [17, 45, 23],
-            cutoff_used: true
+            cutoff_used: true,
+            crap_filtered: true
         };
 
         const peptideData = PeptideData.createFromPeptideDataResponse(response);
@@ -34,6 +35,7 @@ describe("PeptideData", () => {
         expect(peptideData.taxa[0]).toBe(17);
         expect(peptideData.taxa[1]).toBe(45);
         expect(peptideData.cutoffUsed).toBe(true);
+        expect(peptideData.crapFiltered).toBe(true);
     });
 
     it("should correctly serialize and deserialize data", () => {
@@ -50,7 +52,8 @@ describe("PeptideData", () => {
                 data: {"EC:1.2.3.5": 2, "GO:0000001": 35, "IPR:IPR000121": 18}
             },
             taxa: [59, 47, 78],
-            cutoff_used: false
+            cutoff_used: false,
+            crap_filtered: true
         };
 
         const peptideData = PeptideData.createFromPeptideDataResponse(response);
@@ -60,5 +63,6 @@ describe("PeptideData", () => {
         expect(deserializedData.lineage).toEqual(peptideData.lineage);
         expect(deserializedData.faCounts).toEqual(peptideData.faCounts);
         expect(deserializedData.cutoffUsed).toBe(false);
+        expect(deserializedData.crapFiltered).toBe(true);
     });
 });

--- a/src/logic/ontology/peptides/PeptideData.ts
+++ b/src/logic/ontology/peptides/PeptideData.ts
@@ -34,8 +34,12 @@ export default class PeptideData {
     public static readonly FA_GO_INDEX_OFFSET = PeptideData.FA_EC_INDEX_OFFSET + PeptideData.FA_POINTER_SIZE;
     public static readonly FA_IPR_INDEX_OFFSET = PeptideData.FA_GO_INDEX_OFFSET + PeptideData.FA_POINTER_SIZE;
 
+    // 1-byte flag: 1 if the protein match count exceeded the API cutoff, 0 otherwise.
+    public static readonly CUTOFF_USED_OFFSET = PeptideData.FA_IPR_INDEX_OFFSET + PeptideData.FA_POINTER_SIZE;
+    public static readonly CUTOFF_USED_SIZE = 1;
+
     // Where does the variable length data portion of the array start?
-    public static readonly DATA_START = PeptideData.FA_IPR_INDEX_OFFSET + PeptideData.FA_POINTER_SIZE;
+    public static readonly DATA_START = PeptideData.CUTOFF_USED_OFFSET + PeptideData.CUTOFF_USED_SIZE;
 
     // How many bytes do we reserve to keep track of the length of the taxon array?
     public static readonly TAXON_COUNT_SIZE = 4;
@@ -97,6 +101,7 @@ export default class PeptideData {
         // Now convert all the data into a binary format
         const dataView = new DataView(dataBuffer);
         dataView.setUint32(this.LCA_OFFSET, response.lca);
+        dataView.setUint8(this.CUTOFF_USED_OFFSET, response.cutoff_used ? 1 : 0);
 
         // Keep track of the length of the lineage array
         dataView.setUint32(this.LINEAGE_COUNT_OFFSET, response.lineage.length);
@@ -180,6 +185,10 @@ export default class PeptideData {
             go: this.dataView.getUint32(PeptideData.FA_GO_COUNT_OFFSET),
             ipr: this.dataView.getUint32(PeptideData.FA_IPR_COUNT_OFFSET)
         }
+    }
+
+    public get cutoffUsed(): boolean {
+        return this.dataView.getUint8(PeptideData.CUTOFF_USED_OFFSET) !== 0;
     }
 
     public get lca(): number {
@@ -313,6 +322,7 @@ export default class PeptideData {
                 data: dataObject
             },
             taxa: this.taxa,
+            cutoff_used: this.cutoffUsed
         }
     }
 }

--- a/src/logic/ontology/peptides/PeptideData.ts
+++ b/src/logic/ontology/peptides/PeptideData.ts
@@ -38,8 +38,12 @@ export default class PeptideData {
     public static readonly CUTOFF_USED_OFFSET = PeptideData.FA_IPR_INDEX_OFFSET + PeptideData.FA_POINTER_SIZE;
     public static readonly CUTOFF_USED_SIZE = 1;
 
+    // 1-byte flag: 1 if the peptide matches the CRAP blacklist, 0 otherwise.
+    public static readonly CRAP_FILTERED_OFFSET = PeptideData.CUTOFF_USED_OFFSET + PeptideData.CUTOFF_USED_SIZE;
+    public static readonly CRAP_FILTERED_SIZE = 1;
+
     // Where does the variable length data portion of the array start?
-    public static readonly DATA_START = PeptideData.CUTOFF_USED_OFFSET + PeptideData.CUTOFF_USED_SIZE;
+    public static readonly DATA_START = PeptideData.CRAP_FILTERED_OFFSET + PeptideData.CRAP_FILTERED_SIZE;
 
     // How many bytes do we reserve to keep track of the length of the taxon array?
     public static readonly TAXON_COUNT_SIZE = 4;
@@ -102,6 +106,7 @@ export default class PeptideData {
         const dataView = new DataView(dataBuffer);
         dataView.setUint32(this.LCA_OFFSET, response.lca);
         dataView.setUint8(this.CUTOFF_USED_OFFSET, response.cutoff_used ? 1 : 0);
+        dataView.setUint8(this.CRAP_FILTERED_OFFSET, response.crap_filtered ? 1 : 0);
 
         // Keep track of the length of the lineage array
         dataView.setUint32(this.LINEAGE_COUNT_OFFSET, response.lineage.length);
@@ -189,6 +194,10 @@ export default class PeptideData {
 
     public get cutoffUsed(): boolean {
         return this.dataView.getUint8(PeptideData.CUTOFF_USED_OFFSET) !== 0;
+    }
+
+    public get crapFiltered(): boolean {
+        return this.dataView.getUint8(PeptideData.CRAP_FILTERED_OFFSET) !== 0;
     }
 
     public get lca(): number {
@@ -322,7 +331,8 @@ export default class PeptideData {
                 data: dataObject
             },
             taxa: this.taxa,
-            cutoff_used: this.cutoffUsed
+            cutoff_used: this.cutoffUsed,
+            crap_filtered: this.crapFiltered
         }
     }
 }

--- a/src/logic/ontology/peptides/PeptideDataResponse.ts
+++ b/src/logic/ontology/peptides/PeptideDataResponse.ts
@@ -13,7 +13,8 @@ type PeptideDataResponse = {
             data: any
         },
     taxa: number[],
-    cutoff_used: boolean
+    cutoff_used: boolean,
+    crap_filtered: boolean
 };
 
 export default PeptideDataResponse;

--- a/src/logic/ontology/peptides/PeptideDataResponse.ts
+++ b/src/logic/ontology/peptides/PeptideDataResponse.ts
@@ -12,7 +12,8 @@ type PeptideDataResponse = {
                 },
             data: any
         },
-    taxa: number[]
+    taxa: number[],
+    cutoff_used: boolean
 };
 
 export default PeptideDataResponse;

--- a/src/logic/project/ProjectUpgradeManager.ts
+++ b/src/logic/project/ProjectUpgradeManager.ts
@@ -2,6 +2,7 @@ import { SemVer } from "@/logic/project/SemVer";
 import type JSZip from "jszip";
 import type { ProjectUpgrader } from "@/logic/project/ProjectUpgrader";
 import { From635To640Upgrader } from "@/logic/project/upgraders/From635To640Upgrader";
+import { From640To651Upgrader } from "@/logic/project/upgraders/From640To651Upgrader";
 
 /**
  * Coordinates running a chain of {@link ProjectUpgrader}s until a project is
@@ -14,6 +15,7 @@ export class ProjectUpgradeManager {
      */
     private static readonly upgraders: ProjectUpgrader[] = [
         new From635To640Upgrader(),
+        new From640To651Upgrader(),
     ];
 
     private static readonly currentVersion: string = APP_VERSION;

--- a/src/logic/project/ProjectUpgradeManager.ts
+++ b/src/logic/project/ProjectUpgradeManager.ts
@@ -2,7 +2,7 @@ import { SemVer } from "@/logic/project/SemVer";
 import type JSZip from "jszip";
 import type { ProjectUpgrader } from "@/logic/project/ProjectUpgrader";
 import { From635To640Upgrader } from "@/logic/project/upgraders/From635To640Upgrader";
-import { From640To651Upgrader } from "@/logic/project/upgraders/From640To651Upgrader";
+import { From650To651Upgrader } from "@/logic/project/upgraders/From650To651Upgrader";
 
 /**
  * Coordinates running a chain of {@link ProjectUpgrader}s until a project is
@@ -15,7 +15,7 @@ export class ProjectUpgradeManager {
      */
     private static readonly upgraders: ProjectUpgrader[] = [
         new From635To640Upgrader(),
-        new From640To651Upgrader(),
+        new From650To651Upgrader(),
     ];
 
     private static readonly currentVersion: string = APP_VERSION;

--- a/src/logic/project/ProjectUpgradeManager.ts
+++ b/src/logic/project/ProjectUpgradeManager.ts
@@ -21,6 +21,19 @@ export class ProjectUpgradeManager {
     private static readonly currentVersion: string = APP_VERSION;
 
     /**
+     * Returns true if any registered upgrader can be applied to the given project.
+     */
+    public async needsUpgrade(zippedProject: JSZip): Promise<boolean> {
+        const metadataFile = zippedProject.file("metadata.json");
+        if (!metadataFile) return false;
+
+        const metadata = JSON.parse(await metadataFile.async("string")) as { version?: string };
+        if (!metadata.version) return false;
+
+        return SemVer.isOlder(metadata.version, ProjectUpgradeManager.currentVersion);
+    }
+
+    /**
      * Upgrade the given zipped project in-place until its metadata version
      * matches the current application version, or no more upgraders apply.
      *

--- a/src/logic/project/upgraders/From635To640Upgrader.spec.ts
+++ b/src/logic/project/upgraders/From635To640Upgrader.spec.ts
@@ -130,7 +130,8 @@ describe("From635To640Upgrader.upgrade", () => {
                     counts: { all: 10, EC: 5, GO: 3, IPR: 2 },
                     data: { "EC:1.2.3.5": 2, "GO:0000001": 35, "IPR:IPR000121": 18 }
                 },
-                taxa: [17, 45, 23]
+                taxa: [17, 45, 23],
+                cutoff_used: false
             },
             PEPTIDE2: {
                 lca: 2,
@@ -139,7 +140,8 @@ describe("From635To640Upgrader.upgrade", () => {
                     counts: { all: 4, EC: 2, GO: 1, IPR: 1 },
                     data: { "EC:9.9.9.9": 1 }
                 },
-                taxa: [59, 47, 78]
+                taxa: [59, 47, 78],
+                cutoff_used: false
             }
         };
 

--- a/src/logic/project/upgraders/From635To640Upgrader.spec.ts
+++ b/src/logic/project/upgraders/From635To640Upgrader.spec.ts
@@ -131,7 +131,8 @@ describe("From635To640Upgrader.upgrade", () => {
                     data: { "EC:1.2.3.5": 2, "GO:0000001": 35, "IPR:IPR000121": 18 }
                 },
                 taxa: [17, 45, 23],
-                cutoff_used: false
+                cutoff_used: false,
+                crap_filtered: false
             },
             PEPTIDE2: {
                 lca: 2,
@@ -141,7 +142,8 @@ describe("From635To640Upgrader.upgrade", () => {
                     data: { "EC:9.9.9.9": 1 }
                 },
                 taxa: [59, 47, 78],
-                cutoff_used: false
+                cutoff_used: false,
+                crap_filtered: false
             }
         };
 

--- a/src/logic/project/upgraders/From635To640Upgrader.ts
+++ b/src/logic/project/upgraders/From635To640Upgrader.ts
@@ -416,7 +416,8 @@ export class PeptideData_v6_3_5 {
                 data: dataObject
             },
             taxa: this.taxa,
-            cutoff_used: false
+            cutoff_used: false,
+            crap_filtered: false
         }
     }
 }

--- a/src/logic/project/upgraders/From635To640Upgrader.ts
+++ b/src/logic/project/upgraders/From635To640Upgrader.ts
@@ -416,6 +416,7 @@ export class PeptideData_v6_3_5 {
                 data: dataObject
             },
             taxa: this.taxa,
+            cutoff_used: false
         }
     }
 }

--- a/src/logic/project/upgraders/From640To651Upgrader.spec.ts
+++ b/src/logic/project/upgraders/From640To651Upgrader.spec.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import JSZip from "jszip";
+import {
+    From640To651Upgrader,
+    PeptideData_v6_4_0,
+    PeptideDataSerializer_v6_4_0
+} from "@/logic/project/upgraders/From640To651Upgrader";
+import { SemVer } from "@/logic/project/SemVer";
+import { ShareableMap, type TransferableState } from "shared-memory-datastructures";
+import PeptideData from "@/logic/ontology/peptides/PeptideData";
+import PeptideDataResponse from "@/logic/ontology/peptides/PeptideDataResponse";
+import PeptideDataSerializer from "@/logic/ontology/peptides/PeptideDataSerializer";
+import { ArrayBufferUtils } from "@/logic/utils/ArrayBufferUtils";
+
+function createMetadata(version: string, analysisIds: string[] = ["a1"]): any {
+    return {
+        version,
+        groups: [
+            {
+                analyses: analysisIds.map((id) => ({ id, config: {
+                    equate: false,
+                    filter: false,
+                    database: "Test"
+                }}))
+            }
+        ]
+    };
+}
+
+async function createZipWithMetadata(metadata: unknown): Promise<JSZip> {
+    const zip = new JSZip();
+    zip.file("metadata.json", JSON.stringify(metadata));
+    return zip;
+}
+
+/**
+ * Builds a ShareableMap using the v6.4.0 binary format and writes its buffers
+ * into the given zip's buffers/ folder under `analysisId`.
+ */
+async function writeV640Map(
+    zip: JSZip,
+    analysisId: string,
+    entries: Record<string, PeptideDataResponse>
+): Promise<void> {
+    const serializer = new PeptideDataSerializer_v6_4_0();
+    const map = new ShareableMap<string, PeptideData_v6_4_0>({ serializer });
+
+    for (const [peptide, response] of Object.entries(entries)) {
+        // Build a v6.4.0 object by constructing the binary buffer manually.
+        // We reuse the current PeptideData (v6.5.1) factory and then strip the
+        // cutoff byte by reading everything except that 1 byte.  A simpler
+        // approach: just create the v6.4.0 object directly from the response
+        // using the same encoding logic that was present in v6.4.0.
+        const newObj = PeptideData.createFromPeptideDataResponse(response);
+        const oldBuf = stripCutoffByte(newObj.dataView);
+        map.set(peptide, new PeptideData_v6_4_0(oldBuf));
+    }
+
+    const transferable = map.toTransferableState();
+    const indexArray = new Uint8Array(transferable.indexBuffer as SharedArrayBuffer);
+    const dataArray = new Uint8Array(transferable.dataBuffer as SharedArrayBuffer);
+
+    const buffersFolder = zip.folder("buffers")!;
+    buffersFolder.file(`${analysisId}.index`, indexArray.slice().buffer, { binary: true });
+    buffersFolder.file(`${analysisId}.data`, dataArray.slice().buffer, { binary: true });
+}
+
+/**
+ * Produces a DataView that matches the v6.4.0 layout by removing the 1-byte
+ * cutoff_used slot (byte 40) from a v6.5.1 buffer.
+ *
+ * v6.5.1 layout: [...header up to byte 39][cutoff byte 40][variable data from 41]
+ * v6.4.0 layout: [...header up to byte 39][variable data from 40]
+ *
+ * All internal pointers in the variable section must be decremented by 1.
+ */
+function stripCutoffByte(view: DataView): DataView {
+    const src = new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+    const dst = new Uint8Array(src.length - 1);
+
+    // Copy fixed header (bytes 0–39) unchanged.
+    dst.set(src.subarray(0, 40), 0);
+    // Skip byte 40 (cutoff_used), copy variable data from byte 41 onwards.
+    dst.set(src.subarray(41), 40);
+
+    // Adjust the four pointer fields that reference positions in the variable
+    // data section; each stored value was written relative to DATA_START=41
+    // and now needs to be relative to DATA_START=40.
+    const dstView = new DataView(dst.buffer);
+
+    const LINEAGE_ARRAY_INDEX_OFFSET = 8;
+    const FA_EC_INDEX_OFFSET = 28;
+    const FA_GO_INDEX_OFFSET = 32;
+    const FA_IPR_INDEX_OFFSET = 36;
+
+    for (const offset of [LINEAGE_ARRAY_INDEX_OFFSET, FA_EC_INDEX_OFFSET, FA_GO_INDEX_OFFSET, FA_IPR_INDEX_OFFSET]) {
+        dstView.setUint32(offset, dstView.getUint32(offset) - 1);
+    }
+
+    return dstView;
+}
+
+describe("From640To651Upgrader.canUpgrade", () => {
+    it("throws when metadata.json is missing", async () => {
+        const zip = new JSZip();
+        const upgrader = new From640To651Upgrader();
+
+        await expect(upgrader.canUpgrade(zip)).rejects.toThrow(
+            "Failed to find metadata.json while determining upgrade eligibility."
+        );
+    });
+
+    it("throws when version is missing from metadata", async () => {
+        const zip = await createZipWithMetadata({});
+        const upgrader = new From640To651Upgrader();
+
+        await expect(upgrader.canUpgrade(zip)).rejects.toThrow(
+            "Project version is missing in metadata.json. Unable to determine upgrade eligibility."
+        );
+    });
+
+    it("returns true for version equal to 6.5.0", async () => {
+        const spyCompare = vi.spyOn(SemVer, "compare");
+        const zip = await createZipWithMetadata({ version: "6.5.0" });
+        const upgrader = new From640To651Upgrader();
+
+        await expect(upgrader.canUpgrade(zip)).resolves.toBe(true);
+        expect(spyCompare).toHaveBeenCalledWith("6.5.0", "6.5.0");
+    });
+
+    it("returns true for version older than 6.5.0", async () => {
+        const zip = await createZipWithMetadata({ version: "6.4.0" });
+        const upgrader = new From640To651Upgrader();
+
+        await expect(upgrader.canUpgrade(zip)).resolves.toBe(true);
+    });
+
+    it("returns false for version newer than 6.5.0", async () => {
+        const zip = await createZipWithMetadata({ version: "6.5.1" });
+        const upgrader = new From640To651Upgrader();
+
+        await expect(upgrader.canUpgrade(zip)).resolves.toBe(false);
+    });
+});
+
+describe("From640To651Upgrader.upgrade", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("throws when metadata.json is missing during upgrade", async () => {
+        const zip = new JSZip();
+        zip.folder("buffers");
+
+        const upgrader = new From640To651Upgrader();
+
+        await expect(upgrader.upgrade(zip)).rejects.toThrow(
+            "Failed to find metadata.json while upgrading project from 6.4.0 to 6.5.1."
+        );
+    });
+
+    it("throws when peptide data buffers for an analysis are missing", async () => {
+        const metadata = createMetadata("6.5.0", ["missing"]);
+        const zip = await createZipWithMetadata(metadata);
+        zip.folder("buffers");
+
+        const upgrader = new From640To651Upgrader();
+
+        await expect(upgrader.upgrade(zip)).rejects.toThrow(
+            "Failed to find peptide data buffers for analysis 'missing' while upgrading project from 6.4.0 to 6.5.1."
+        );
+    });
+
+    it("upgrades buffers, sets cutoff_used based on fa.counts.all, and bumps version to 6.5.1", async () => {
+        const metadata = createMetadata("6.5.0", ["a1"]);
+        const zip = await createZipWithMetadata(metadata);
+        zip.folder("buffers");
+
+        const responses: Record<string, PeptideDataResponse> = {
+            // all > 9000 → cutoff_used should be true after upgrade
+            PEPTIDE_OVER: {
+                lca: 1,
+                lineage: [1, 2, 3],
+                fa: {
+                    counts: { all: 10000, EC: 2, GO: 1, IPR: 1 },
+                    data: { "EC:1.2.3.4": 2, "GO:0000001": 10, "IPR:IPR000001": 5 }
+                },
+                taxa: [10, 20],
+                cutoff_used: false
+            },
+            // all <= 9000 → cutoff_used should be false after upgrade
+            PEPTIDE_UNDER: {
+                lca: 2,
+                lineage: [4, 5, 6],
+                fa: {
+                    counts: { all: 5000, EC: 1, GO: 0, IPR: 0 },
+                    data: { "EC:9.9.9.9": 1 }
+                },
+                taxa: [30],
+                cutoff_used: false
+            }
+        };
+
+        await writeV640Map(zip, "a1", responses);
+
+        const upgrader = new From640To651Upgrader();
+        const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+        const upgraded = await upgrader.upgrade(zip);
+
+        const updatedMetadata = JSON.parse(await upgraded.file("metadata.json")!.async("string"));
+        expect(updatedMetadata.version).toBe("6.5.1");
+
+        const upgradedBuffersFolder = upgraded.folder("buffers")!;
+        const newIndexArrayBuffer = await upgradedBuffersFolder.file("a1.index")!.async("arraybuffer");
+        const newDataArrayBuffer = await upgradedBuffersFolder.file("a1.data")!.async("arraybuffer");
+
+        const newIndexShared = ArrayBufferUtils.arrayBufferToShared(newIndexArrayBuffer);
+        const newDataShared = ArrayBufferUtils.arrayBufferToShared(newDataArrayBuffer);
+
+        const newTransferable: TransferableState = {
+            indexBuffer: newIndexShared,
+            dataBuffer: newDataShared
+        };
+
+        const mapV2 = ShareableMap.fromTransferableState<string, PeptideData>(
+            newTransferable,
+            { serializer: new PeptideDataSerializer() }
+        );
+
+        expect(Array.from(mapV2.keys()).sort()).toEqual(Object.keys(responses).sort());
+
+        const over = mapV2.get("PEPTIDE_OVER")!;
+        expect(over.cutoffUsed).toBe(true);
+        expect(over.lca).toBe(responses["PEPTIDE_OVER"].lca);
+        expect(over.faCounts.all).toBe(10000);
+
+        const under = mapV2.get("PEPTIDE_UNDER")!;
+        expect(under.cutoffUsed).toBe(false);
+        expect(under.lca).toBe(responses["PEPTIDE_UNDER"].lca);
+        expect(under.faCounts.all).toBe(5000);
+
+        consoleSpy.mockRestore();
+    });
+});

--- a/src/logic/project/upgraders/From640To651Upgrader.spec.ts
+++ b/src/logic/project/upgraders/From640To651Upgrader.spec.ts
@@ -144,14 +144,15 @@ describe("From640To651Upgrader.canUpgrade", () => {
 });
 
 /**
- * Creates a mock fetch that returns crap_filtered values for the given peptide sequences.
+ * Creates a mock fetch that returns crap_filtered and cutoff_used values for the given peptide sequences.
  */
-function mockFetchCrapFiltered(crapMap: Record<string, boolean>) {
+function mockFetchApiFlags(flagsMap: Record<string, { crap_filtered?: boolean; cutoff_used?: boolean }>) {
     vi.stubGlobal("fetch", vi.fn((_url: string, options: RequestInit) => {
         const body = JSON.parse(options.body as string);
         const peptides = (body.peptides as string[]).map((sequence) => ({
             sequence,
-            crap_filtered: crapMap[sequence] ?? false
+            crap_filtered: flagsMap[sequence]?.crap_filtered ?? false,
+            cutoff_used: flagsMap[sequence]?.cutoff_used ?? false
         }));
         return Promise.resolve({
             json: () => Promise.resolve({ peptides })
@@ -182,7 +183,7 @@ describe("From640To651Upgrader.upgrade", () => {
     });
 
     it("throws when peptide data buffers for an analysis are missing", async () => {
-        mockFetchCrapFiltered({});
+        mockFetchApiFlags({});
         const metadata = createMetadata("6.5.0", ["missing"]);
         const zip = await createZipWithMetadata(metadata);
         zip.folder("buffers");
@@ -195,9 +196,9 @@ describe("From640To651Upgrader.upgrade", () => {
     });
 
     it("upgrades buffers, sets cutoff_used and crap_filtered, and bumps version to 6.5.1", async () => {
-        mockFetchCrapFiltered({
-            PEPTIDE_OVER: true,
-            PEPTIDE_UNDER: false
+        mockFetchApiFlags({
+            PEPTIDE_OVER: { crap_filtered: true, cutoff_used: true },
+            PEPTIDE_UNDER: { crap_filtered: false, cutoff_used: false }
         });
 
         const metadata = createMetadata("6.5.0", ["a1"]);
@@ -205,7 +206,7 @@ describe("From640To651Upgrader.upgrade", () => {
         zip.folder("buffers");
 
         const responses: Record<string, PeptideDataResponse> = {
-            // all > 9000 → cutoff_used should be true after upgrade
+            // API returns cutoff_used: true and crap_filtered: true for this peptide
             PEPTIDE_OVER: {
                 lca: 1,
                 lineage: [1, 2, 3],
@@ -217,7 +218,7 @@ describe("From640To651Upgrader.upgrade", () => {
                 cutoff_used: false,
                 crap_filtered: false
             },
-            // all <= 9000 → cutoff_used should be false after upgrade
+            // API returns cutoff_used: false and crap_filtered: false for this peptide
             PEPTIDE_UNDER: {
                 lca: 2,
                 lineage: [4, 5, 6],

--- a/src/logic/project/upgraders/From640To651Upgrader.spec.ts
+++ b/src/logic/project/upgraders/From640To651Upgrader.spec.ts
@@ -143,13 +143,31 @@ describe("From640To651Upgrader.canUpgrade", () => {
     });
 });
 
+/**
+ * Creates a mock fetch that returns crap_filtered values for the given peptide sequences.
+ */
+function mockFetchCrapFiltered(crapMap: Record<string, boolean>) {
+    vi.stubGlobal("fetch", vi.fn((_url: string, options: RequestInit) => {
+        const body = JSON.parse(options.body as string);
+        const peptides = (body.peptides as string[]).map((sequence) => ({
+            sequence,
+            crap_filtered: crapMap[sequence] ?? false
+        }));
+        return Promise.resolve({
+            json: () => Promise.resolve({ peptides })
+        });
+    }));
+}
+
 describe("From640To651Upgrader.upgrade", () => {
     beforeEach(() => {
         vi.restoreAllMocks();
+        vi.unstubAllGlobals();
     });
 
     afterEach(() => {
         vi.restoreAllMocks();
+        vi.unstubAllGlobals();
     });
 
     it("throws when metadata.json is missing during upgrade", async () => {
@@ -164,6 +182,7 @@ describe("From640To651Upgrader.upgrade", () => {
     });
 
     it("throws when peptide data buffers for an analysis are missing", async () => {
+        mockFetchCrapFiltered({});
         const metadata = createMetadata("6.5.0", ["missing"]);
         const zip = await createZipWithMetadata(metadata);
         zip.folder("buffers");
@@ -175,7 +194,12 @@ describe("From640To651Upgrader.upgrade", () => {
         );
     });
 
-    it("upgrades buffers, sets cutoff_used based on fa.counts.all, and bumps version to 6.5.1", async () => {
+    it("upgrades buffers, sets cutoff_used and crap_filtered, and bumps version to 6.5.1", async () => {
+        mockFetchCrapFiltered({
+            PEPTIDE_OVER: true,
+            PEPTIDE_UNDER: false
+        });
+
         const metadata = createMetadata("6.5.0", ["a1"]);
         const zip = await createZipWithMetadata(metadata);
         zip.folder("buffers");
@@ -190,7 +214,8 @@ describe("From640To651Upgrader.upgrade", () => {
                     data: { "EC:1.2.3.4": 2, "GO:0000001": 10, "IPR:IPR000001": 5 }
                 },
                 taxa: [10, 20],
-                cutoff_used: false
+                cutoff_used: false,
+                crap_filtered: false
             },
             // all <= 9000 → cutoff_used should be false after upgrade
             PEPTIDE_UNDER: {
@@ -201,14 +226,14 @@ describe("From640To651Upgrader.upgrade", () => {
                     data: { "EC:9.9.9.9": 1 }
                 },
                 taxa: [30],
-                cutoff_used: false
+                cutoff_used: false,
+                crap_filtered: false
             }
         };
 
         await writeV640Map(zip, "a1", responses);
 
         const upgrader = new From640To651Upgrader();
-        const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
         const upgraded = await upgrader.upgrade(zip);
 
@@ -236,14 +261,14 @@ describe("From640To651Upgrader.upgrade", () => {
 
         const over = mapV2.get("PEPTIDE_OVER")!;
         expect(over.cutoffUsed).toBe(true);
+        expect(over.crapFiltered).toBe(true);
         expect(over.lca).toBe(responses["PEPTIDE_OVER"].lca);
         expect(over.faCounts.all).toBe(10000);
 
         const under = mapV2.get("PEPTIDE_UNDER")!;
         expect(under.cutoffUsed).toBe(false);
+        expect(under.crapFiltered).toBe(false);
         expect(under.lca).toBe(responses["PEPTIDE_UNDER"].lca);
         expect(under.faCounts.all).toBe(5000);
-
-        consoleSpy.mockRestore();
     });
 });

--- a/src/logic/project/upgraders/From640To651Upgrader.ts
+++ b/src/logic/project/upgraders/From640To651Upgrader.ts
@@ -7,6 +7,7 @@ import PeptideDataSerializer from "@/logic/ontology/peptides/PeptideDataSerializ
 import { ArrayBufferUtils } from "@/logic/utils/ArrayBufferUtils";
 import { Serializable } from "shared-memory-datastructures";
 import PeptideDataResponse from "@/logic/ontology/peptides/PeptideDataResponse";
+import { DEFAULT_API_BASE_URL, DEFAULT_BATCH_SIZE } from "@/logic/Constants";
 
 
 /**
@@ -52,7 +53,7 @@ export class From640To651Upgrader implements ProjectUpgrader {
 
         const metadata = JSON.parse(await metadataFile.async("string")) as {
             groups: Array<{
-                analyses: Array<{ id: string }>;
+                analyses: Array<{ id: string; config: { equate: boolean } }>;
             }>;
         };
 
@@ -81,11 +82,15 @@ export class From640To651Upgrader implements ProjectUpgrader {
                     { serializer: new PeptideDataSerializer_v6_4_0() }
                 );
 
+                const sequences = Array.from(oldMap.keys());
+                const crapFilteredMap = await this.fetchCrapFiltered(sequences, analysis.config.equate);
+
                 const newMap = new ShareableMap<string, PeptideData>({ serializer: new PeptideDataSerializer() });
 
                 for (const [peptide, old] of oldMap) {
                     const response = old.toPeptideDataResponse();
                     response.cutoff_used = response.fa.counts.all > 9000;
+                    response.crap_filtered = crapFilteredMap.get(peptide) ?? false;
                     newMap.set(peptide, PeptideData.createFromPeptideDataResponse(response));
                 }
 
@@ -104,6 +109,29 @@ export class From640To651Upgrader implements ProjectUpgrader {
         zippedProject.file("metadata.json", JSON.stringify(updatedMetadata));
 
         return zippedProject;
+    }
+
+    private async fetchCrapFiltered(sequences: string[], equate: boolean): Promise<Map<string, boolean>> {
+        const result = new Map<string, boolean>();
+
+        for (let i = 0; i < sequences.length; i += DEFAULT_BATCH_SIZE) {
+            const batch = sequences.slice(i, i + DEFAULT_BATCH_SIZE);
+            const response = await fetch(`${DEFAULT_API_BASE_URL}/mpa/pept2data`, {
+                method: "POST",
+                body: JSON.stringify({
+                    peptides: batch,
+                    equate_il: equate,
+                    report_taxa: false
+                }),
+                headers: { "Content-Type": "application/json" }
+            }).then(r => r.json());
+
+            for (const peptide of response.peptides ?? []) {
+                result.set(peptide.sequence, peptide.crap_filtered ?? false);
+            }
+        }
+
+        return result;
     }
 }
 
@@ -272,7 +300,8 @@ export class PeptideData_v6_4_0 {
                 data: dataObject
             },
             taxa: this.taxa,
-            cutoff_used: false
+            cutoff_used: false,
+            crap_filtered: false
         };
     }
 }

--- a/src/logic/project/upgraders/From640To651Upgrader.ts
+++ b/src/logic/project/upgraders/From640To651Upgrader.ts
@@ -1,0 +1,298 @@
+import type JSZip from "jszip";
+import type { ProjectUpgrader } from "@/logic/project/ProjectUpgrader";
+import { SemVer } from "@/logic/project/SemVer";
+import { ShareableMap, type TransferableState } from "shared-memory-datastructures";
+import PeptideData from "@/logic/ontology/peptides/PeptideData";
+import PeptideDataSerializer from "@/logic/ontology/peptides/PeptideDataSerializer";
+import { ArrayBufferUtils } from "@/logic/utils/ArrayBufferUtils";
+import { Serializable } from "shared-memory-datastructures";
+import PeptideDataResponse from "@/logic/ontology/peptides/PeptideDataResponse";
+
+
+/**
+ * Upgrades a project exported with version ≤ 6.5.0 to the 6.5.1 schema.
+ *
+ * Between 6.5.0 and 6.5.1 a `cutoff_used` flag was added to the binary
+ * PeptideData format (1 byte at offset 40). Projects created before this
+ * change lack that byte; the upgrader re-encodes every PeptideData entry and
+ * back-fills the flag: true when fa.counts.all > 9000, false otherwise.
+ *
+ * @author Pieter Verschaffelt
+ */
+export class From640To651Upgrader implements ProjectUpgrader {
+    public readonly name = "From 6.4.0 to 6.5.1";
+
+    public async canUpgrade(zippedProject: JSZip): Promise<boolean> {
+        const metadataFile = zippedProject.file("metadata.json");
+
+        if (!metadataFile) {
+            throw new Error("Failed to find metadata.json while determining upgrade eligibility.");
+        }
+
+        const metadata = JSON.parse(await metadataFile.async("string")) as { version?: string };
+
+        if (!metadata.version) {
+            throw new Error("Project version is missing in metadata.json. Unable to determine upgrade eligibility.");
+        }
+
+        return SemVer.compare(metadata.version, "6.5.0") <= 0;
+    }
+
+    public async upgrade(zippedProject: JSZip): Promise<JSZip> {
+        const buffersFolder = zippedProject.folder("buffers");
+
+        if (!buffersFolder) {
+            throw new Error("Failed to find buffers folder while upgrading project from 6.4.0 to 6.5.1.");
+        }
+
+        const metadataFile = zippedProject.file("metadata.json");
+        if (!metadataFile) {
+            throw new Error("Failed to find metadata.json while upgrading project from 6.4.0 to 6.5.1.");
+        }
+
+        const metadata = JSON.parse(await metadataFile.async("string")) as {
+            groups: Array<{
+                analyses: Array<{ id: string }>;
+            }>;
+        };
+
+        for (const group of metadata.groups) {
+            for (const analysis of group.analyses) {
+                const indexFile = buffersFolder.file(`${analysis.id}.index`);
+                const dataFile = buffersFolder.file(`${analysis.id}.data`);
+
+                if (!indexFile || !dataFile) {
+                    throw new Error(`Failed to find peptide data buffers for analysis '${analysis.id}' while upgrading project from 6.4.0 to 6.5.1.`);
+                }
+
+                const indexArrayBuffer = await indexFile.async("arraybuffer");
+                const dataArrayBuffer = await dataFile.async("arraybuffer");
+
+                const indexShared = ArrayBufferUtils.arrayBufferToShared(indexArrayBuffer);
+                const dataShared = ArrayBufferUtils.arrayBufferToShared(dataArrayBuffer);
+
+                const transferableState: TransferableState = {
+                    indexBuffer: indexShared,
+                    dataBuffer: dataShared
+                };
+
+                const oldMap = ShareableMap.fromTransferableState<string, PeptideData_v6_4_0>(
+                    transferableState,
+                    { serializer: new PeptideDataSerializer_v6_4_0() }
+                );
+
+                const newMap = new ShareableMap<string, PeptideData>({ serializer: new PeptideDataSerializer() });
+
+                for (const [peptide, old] of oldMap) {
+                    const response = old.toPeptideDataResponse();
+                    response.cutoff_used = response.fa.counts.all > 9000;
+                    newMap.set(peptide, PeptideData.createFromPeptideDataResponse(response));
+                }
+
+                const newTransferable = newMap.toTransferableState();
+
+                const newIndexArray = new Uint8Array(newTransferable.indexBuffer as SharedArrayBuffer);
+                const newDataArray = new Uint8Array(newTransferable.dataBuffer as SharedArrayBuffer);
+
+                buffersFolder.file(`${analysis.id}.index`, newIndexArray.slice().buffer, { binary: true });
+                buffersFolder.file(`${analysis.id}.data`, newDataArray.slice().buffer, { binary: true });
+            }
+        }
+
+        const updatedMetadata = JSON.parse(await metadataFile.async("string"));
+        updatedMetadata.version = "6.5.1";
+        zippedProject.file("metadata.json", JSON.stringify(updatedMetadata));
+
+        return zippedProject;
+    }
+}
+
+
+/**
+ * Snapshot of the binary PeptideData format used from Unipept v6.4.0 up to
+ * and including v6.5.0. DATA_START is at byte 40 (no cutoff_used byte).
+ */
+export class PeptideData_v6_4_0 {
+    public static readonly LCA_OFFSET: number = 0;
+    public static readonly LCA_SIZE: number = 4;
+
+    public static readonly LINEAGE_COUNT_OFFSET: number = PeptideData_v6_4_0.LCA_OFFSET + PeptideData_v6_4_0.LCA_SIZE;
+    public static readonly LINEAGE_COUNT_SIZE: number = 4;
+    public static readonly LINEAGE_ARRAY_INDEX_OFFSET: number = PeptideData_v6_4_0.LINEAGE_COUNT_OFFSET + PeptideData_v6_4_0.LINEAGE_COUNT_SIZE;
+    public static readonly LINEAGE_ARRAY_POINTER_SIZE: number = 4;
+
+    public static readonly FA_COUNT_SIZE = 4;
+
+    public static readonly FA_ALL_COUNT_OFFSET = PeptideData_v6_4_0.LINEAGE_ARRAY_INDEX_OFFSET + PeptideData_v6_4_0.LINEAGE_ARRAY_POINTER_SIZE;
+    public static readonly FA_EC_COUNT_OFFSET = PeptideData_v6_4_0.FA_ALL_COUNT_OFFSET + PeptideData_v6_4_0.FA_COUNT_SIZE;
+    public static readonly FA_GO_COUNT_OFFSET = PeptideData_v6_4_0.FA_EC_COUNT_OFFSET + PeptideData_v6_4_0.FA_COUNT_SIZE;
+    public static readonly FA_IPR_COUNT_OFFSET = PeptideData_v6_4_0.FA_GO_COUNT_OFFSET + PeptideData_v6_4_0.FA_COUNT_SIZE;
+
+    public static readonly FA_POINTER_SIZE = 4;
+
+    public static readonly FA_EC_INDEX_OFFSET = PeptideData_v6_4_0.FA_IPR_COUNT_OFFSET + PeptideData_v6_4_0.FA_COUNT_SIZE;
+    public static readonly FA_GO_INDEX_OFFSET = PeptideData_v6_4_0.FA_EC_INDEX_OFFSET + PeptideData_v6_4_0.FA_POINTER_SIZE;
+    public static readonly FA_IPR_INDEX_OFFSET = PeptideData_v6_4_0.FA_GO_INDEX_OFFSET + PeptideData_v6_4_0.FA_POINTER_SIZE;
+
+    public static readonly DATA_START = PeptideData_v6_4_0.FA_IPR_INDEX_OFFSET + PeptideData_v6_4_0.FA_POINTER_SIZE;
+
+    public static readonly TAXON_COUNT_SIZE = 4;
+    public static readonly TAXON_SIZE = 4;
+
+    public get TAXA_START() {
+        let goStart = this.dataView.getUint32(PeptideData_v6_4_0.FA_GO_INDEX_OFFSET);
+        const goLength = this.dataView.getUint32(goStart);
+
+        let ecStart = this.dataView.getUint32(PeptideData_v6_4_0.FA_EC_INDEX_OFFSET);
+        const ecLength = this.dataView.getUint32(ecStart);
+
+        let iprStart = this.dataView.getUint32(PeptideData_v6_4_0.FA_IPR_INDEX_OFFSET);
+        const iprLength = this.dataView.getUint32(iprStart);
+
+        const lineageLength = this.dataView.getUint32(PeptideData_v6_4_0.LINEAGE_COUNT_OFFSET);
+        const lineageDataLength = PeptideData_v6_4_0.LINEAGE_COUNT_SIZE + lineageLength * 4;
+
+        const faDataLength = 12 + goLength * 8 + iprLength * 8 + ecLength * 20;
+        return PeptideData_v6_4_0.DATA_START + faDataLength + lineageDataLength;
+    }
+
+    constructor(
+        public readonly dataView: DataView
+    ) {}
+
+    public get faCounts(): { all: number, ec: number, go: number, ipr: number } {
+        return {
+            all: this.dataView.getUint32(PeptideData_v6_4_0.FA_ALL_COUNT_OFFSET),
+            ec: this.dataView.getUint32(PeptideData_v6_4_0.FA_EC_COUNT_OFFSET),
+            go: this.dataView.getUint32(PeptideData_v6_4_0.FA_GO_COUNT_OFFSET),
+            ipr: this.dataView.getUint32(PeptideData_v6_4_0.FA_IPR_COUNT_OFFSET)
+        };
+    }
+
+    public get lca(): number {
+        return this.dataView.getUint32(PeptideData_v6_4_0.LCA_OFFSET);
+    }
+
+    public get lineage(): (number | null)[] {
+        const length = this.dataView.getUint32(PeptideData_v6_4_0.LINEAGE_COUNT_OFFSET);
+        const lineagePointer = this.dataView.getUint32(PeptideData_v6_4_0.LINEAGE_ARRAY_INDEX_OFFSET);
+
+        const lin = [];
+        for (let i = 0; i < length; i++) {
+            const val = this.dataView.getInt32(lineagePointer + i * 4);
+            lin.push(val === 0 ? null : val);
+        }
+        return lin;
+    }
+
+    public get ec(): any {
+        const output: any = {};
+
+        let ecStart = this.dataView.getUint32(PeptideData_v6_4_0.FA_EC_INDEX_OFFSET);
+        const ecLength = this.dataView.getUint32(ecStart);
+        ecStart += 4;
+
+        for (let i = 0; i < ecLength; i++) {
+            const part1 = this.encodedNullOrNumberToString(this.dataView.getInt32(ecStart));
+            const part2 = this.encodedNullOrNumberToString(this.dataView.getInt32(ecStart + 4));
+            const part3 = this.encodedNullOrNumberToString(this.dataView.getInt32(ecStart + 8));
+            const part4 = this.encodedNullOrNumberToString(this.dataView.getInt32(ecStart + 12));
+            output[`EC:${part1}.${part2}.${part3}.${part4}`] = this.dataView.getUint32(ecStart + 16);
+            ecStart += 20;
+        }
+
+        return output;
+    }
+
+    private encodedNullOrNumberToString(value: number): string {
+        return value === -1 ? "-" : value.toString();
+    }
+
+    public get go(): any {
+        const output: any = {};
+
+        let goStart = this.dataView.getUint32(PeptideData_v6_4_0.FA_GO_INDEX_OFFSET);
+        const goLength = this.dataView.getUint32(goStart);
+        goStart += 4;
+
+        for (let i = 0; i < goLength; i++) {
+            const term = this.dataView.getUint32(goStart);
+            output["GO:" + term.toString().padStart(7, "0")] = this.dataView.getUint32(goStart + 4);
+            goStart += 8;
+        }
+
+        return output;
+    }
+
+    public get ipr(): any {
+        const output: any = {};
+
+        let iprStart = this.dataView.getUint32(PeptideData_v6_4_0.FA_IPR_INDEX_OFFSET);
+        const iprLength = this.dataView.getUint32(iprStart);
+        iprStart += 4;
+
+        for (let i = 0; i < iprLength; i++) {
+            const term = this.dataView.getUint32(iprStart);
+            output["IPR:IPR" + term.toString().padStart(6, "0")] = this.dataView.getUint32(iprStart + 4);
+            iprStart += 8;
+        }
+
+        return output;
+    }
+
+    public get taxa(): number[] {
+        const output = [];
+        const taxaLength = this.dataView.getUint32(this.TAXA_START);
+
+        for (let i = 0; i < taxaLength; i++) {
+            output.push(this.dataView.getUint32(this.TAXA_START + PeptideData_v6_4_0.TAXON_COUNT_SIZE + i * PeptideData_v6_4_0.TAXON_SIZE));
+        }
+
+        return output;
+    }
+
+    public toPeptideDataResponse(): PeptideDataResponse {
+        const faCounts = this.faCounts;
+
+        const dataObject = {};
+        Object.assign(dataObject, this.go);
+        Object.assign(dataObject, this.ec);
+        Object.assign(dataObject, this.ipr);
+
+        return {
+            lca: this.lca,
+            lineage: this.lineage,
+            fa: {
+                counts: {
+                    all: faCounts.all,
+                    EC: faCounts.ec,
+                    GO: faCounts.go,
+                    IPR: faCounts.ipr
+                },
+                data: dataObject
+            },
+            taxa: this.taxa,
+            cutoff_used: false
+        };
+    }
+}
+
+
+export class PeptideDataSerializer_v6_4_0 implements Serializable<PeptideData_v6_4_0> {
+    public decode(buffer: Uint8Array): PeptideData_v6_4_0 {
+        return new PeptideData_v6_4_0(new DataView(buffer.buffer));
+    }
+
+    public encode(object: PeptideData_v6_4_0, destination: Uint8Array): number {
+        destination.set(new Uint8Array(
+            object.dataView.buffer,
+            object.dataView.byteOffset,
+            object.dataView.byteLength
+        ));
+        return object.dataView.byteLength;
+    }
+
+    public maximumLength(object: PeptideData_v6_4_0): number {
+        return object.dataView.byteLength;
+    }
+}

--- a/src/logic/project/upgraders/From640To651Upgrader.ts
+++ b/src/logic/project/upgraders/From640To651Upgrader.ts
@@ -16,7 +16,7 @@ import { DEFAULT_API_BASE_URL, DEFAULT_BATCH_SIZE } from "@/logic/Constants";
  * Between 6.5.0 and 6.5.1 a `cutoff_used` flag was added to the binary
  * PeptideData format (1 byte at offset 40). Projects created before this
  * change lack that byte; the upgrader re-encodes every PeptideData entry and
- * back-fills the flag: true when fa.counts.all > 9000, false otherwise.
+ * back-fills both `cutoff_used` and `crap_filtered` by querying the API.
  *
  * @author Pieter Verschaffelt
  */
@@ -52,6 +52,7 @@ export class From640To651Upgrader implements ProjectUpgrader {
         }
 
         const metadata = JSON.parse(await metadataFile.async("string")) as {
+            version: string;
             groups: Array<{
                 analyses: Array<{ id: string; config: { equate: boolean } }>;
             }>;
@@ -83,14 +84,15 @@ export class From640To651Upgrader implements ProjectUpgrader {
                 );
 
                 const sequences = Array.from(oldMap.keys());
-                const crapFilteredMap = await this.fetchCrapFiltered(sequences, analysis.config.equate);
+                const crapFilteredMap = await this.fetchApiFlags(sequences, analysis.config.equate);
 
                 const newMap = new ShareableMap<string, PeptideData>({ serializer: new PeptideDataSerializer() });
 
                 for (const [peptide, old] of oldMap) {
                     const response = old.toPeptideDataResponse();
-                    response.cutoff_used = response.fa.counts.all > 9000;
-                    response.crap_filtered = crapFilteredMap.get(peptide) ?? false;
+                    const flags = crapFilteredMap.get(peptide);
+                    response.cutoff_used = flags?.cutoff_used ?? false;
+                    response.crap_filtered = flags?.crap_filtered ?? false;
                     newMap.set(peptide, PeptideData.createFromPeptideDataResponse(response));
                 }
 
@@ -104,15 +106,17 @@ export class From640To651Upgrader implements ProjectUpgrader {
             }
         }
 
-        const updatedMetadata = JSON.parse(await metadataFile.async("string"));
-        updatedMetadata.version = "6.5.1";
-        zippedProject.file("metadata.json", JSON.stringify(updatedMetadata));
+        metadata.version = "6.5.1";
+        zippedProject.file("metadata.json", JSON.stringify(metadata));
 
         return zippedProject;
     }
 
-    private async fetchCrapFiltered(sequences: string[], equate: boolean): Promise<Map<string, boolean>> {
-        const result = new Map<string, boolean>();
+    private async fetchApiFlags(
+        sequences: string[],
+        equate: boolean
+    ): Promise<Map<string, { crap_filtered: boolean; cutoff_used: boolean }>> {
+        const result = new Map<string, { crap_filtered: boolean; cutoff_used: boolean }>();
 
         for (let i = 0; i < sequences.length; i += DEFAULT_BATCH_SIZE) {
             const batch = sequences.slice(i, i + DEFAULT_BATCH_SIZE);
@@ -127,7 +131,10 @@ export class From640To651Upgrader implements ProjectUpgrader {
             }).then(r => r.json());
 
             for (const peptide of response.peptides ?? []) {
-                result.set(peptide.sequence, peptide.crap_filtered ?? false);
+                result.set(peptide.sequence, {
+                    crap_filtered: peptide.crap_filtered ?? false,
+                    cutoff_used: peptide.cutoff_used ?? false
+                });
             }
         }
 
@@ -213,8 +220,8 @@ export class PeptideData_v6_4_0 {
         return lin;
     }
 
-    public get ec(): any {
-        const output: any = {};
+    public get ec(): Record<string, number> {
+        const output: Record<string, number> = {};
 
         let ecStart = this.dataView.getUint32(PeptideData_v6_4_0.FA_EC_INDEX_OFFSET);
         const ecLength = this.dataView.getUint32(ecStart);
@@ -236,8 +243,8 @@ export class PeptideData_v6_4_0 {
         return value === -1 ? "-" : value.toString();
     }
 
-    public get go(): any {
-        const output: any = {};
+    public get go(): Record<string, number> {
+        const output: Record<string, number> = {};
 
         let goStart = this.dataView.getUint32(PeptideData_v6_4_0.FA_GO_INDEX_OFFSET);
         const goLength = this.dataView.getUint32(goStart);
@@ -252,8 +259,8 @@ export class PeptideData_v6_4_0 {
         return output;
     }
 
-    public get ipr(): any {
-        const output: any = {};
+    public get ipr(): Record<string, number> {
+        const output: Record<string, number> = {};
 
         let iprStart = this.dataView.getUint32(PeptideData_v6_4_0.FA_IPR_INDEX_OFFSET);
         const iprLength = this.dataView.getUint32(iprStart);

--- a/src/logic/project/upgraders/From650To651Upgrader.spec.ts
+++ b/src/logic/project/upgraders/From650To651Upgrader.spec.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import JSZip from "jszip";
 import {
-    From640To651Upgrader,
+    From650To651Upgrader,
     PeptideData_v6_4_0,
     PeptideDataSerializer_v6_4_0
-} from "@/logic/project/upgraders/From640To651Upgrader";
+} from "@/logic/project/upgraders/From650To651Upgrader";
 import { SemVer } from "@/logic/project/SemVer";
 import { ShareableMap, type TransferableState } from "shared-memory-datastructures";
 import PeptideData from "@/logic/ontology/peptides/PeptideData";
@@ -100,10 +100,10 @@ function stripCutoffByte(view: DataView): DataView {
     return dstView;
 }
 
-describe("From640To651Upgrader.canUpgrade", () => {
+describe("From650To651Upgrader.canUpgrade", () => {
     it("throws when metadata.json is missing", async () => {
         const zip = new JSZip();
-        const upgrader = new From640To651Upgrader();
+        const upgrader = new From650To651Upgrader();
 
         await expect(upgrader.canUpgrade(zip)).rejects.toThrow(
             "Failed to find metadata.json while determining upgrade eligibility."
@@ -112,7 +112,7 @@ describe("From640To651Upgrader.canUpgrade", () => {
 
     it("throws when version is missing from metadata", async () => {
         const zip = await createZipWithMetadata({});
-        const upgrader = new From640To651Upgrader();
+        const upgrader = new From650To651Upgrader();
 
         await expect(upgrader.canUpgrade(zip)).rejects.toThrow(
             "Project version is missing in metadata.json. Unable to determine upgrade eligibility."
@@ -122,7 +122,7 @@ describe("From640To651Upgrader.canUpgrade", () => {
     it("returns true for version equal to 6.5.0", async () => {
         const spyCompare = vi.spyOn(SemVer, "compare");
         const zip = await createZipWithMetadata({ version: "6.5.0" });
-        const upgrader = new From640To651Upgrader();
+        const upgrader = new From650To651Upgrader();
 
         await expect(upgrader.canUpgrade(zip)).resolves.toBe(true);
         expect(spyCompare).toHaveBeenCalledWith("6.5.0", "6.5.0");
@@ -130,14 +130,14 @@ describe("From640To651Upgrader.canUpgrade", () => {
 
     it("returns true for version older than 6.5.0", async () => {
         const zip = await createZipWithMetadata({ version: "6.4.0" });
-        const upgrader = new From640To651Upgrader();
+        const upgrader = new From650To651Upgrader();
 
         await expect(upgrader.canUpgrade(zip)).resolves.toBe(true);
     });
 
     it("returns false for version newer than 6.5.0", async () => {
         const zip = await createZipWithMetadata({ version: "6.5.1" });
-        const upgrader = new From640To651Upgrader();
+        const upgrader = new From650To651Upgrader();
 
         await expect(upgrader.canUpgrade(zip)).resolves.toBe(false);
     });
@@ -155,12 +155,13 @@ function mockFetchApiFlags(flagsMap: Record<string, { crap_filtered?: boolean; c
             cutoff_used: flagsMap[sequence]?.cutoff_used ?? false
         }));
         return Promise.resolve({
+            ok: true,
             json: () => Promise.resolve({ peptides })
         });
     }));
 }
 
-describe("From640To651Upgrader.upgrade", () => {
+describe("From650To651Upgrader.upgrade", () => {
     beforeEach(() => {
         vi.restoreAllMocks();
         vi.unstubAllGlobals();
@@ -175,7 +176,7 @@ describe("From640To651Upgrader.upgrade", () => {
         const zip = new JSZip();
         zip.folder("buffers");
 
-        const upgrader = new From640To651Upgrader();
+        const upgrader = new From650To651Upgrader();
 
         await expect(upgrader.upgrade(zip)).rejects.toThrow(
             "Failed to find metadata.json while upgrading project from 6.4.0 to 6.5.1."
@@ -188,7 +189,7 @@ describe("From640To651Upgrader.upgrade", () => {
         const zip = await createZipWithMetadata(metadata);
         zip.folder("buffers");
 
-        const upgrader = new From640To651Upgrader();
+        const upgrader = new From650To651Upgrader();
 
         await expect(upgrader.upgrade(zip)).rejects.toThrow(
             "Failed to find peptide data buffers for analysis 'missing' while upgrading project from 6.4.0 to 6.5.1."
@@ -234,7 +235,7 @@ describe("From640To651Upgrader.upgrade", () => {
 
         await writeV640Map(zip, "a1", responses);
 
-        const upgrader = new From640To651Upgrader();
+        const upgrader = new From650To651Upgrader();
 
         const upgraded = await upgrader.upgrade(zip);
 

--- a/src/logic/project/upgraders/From650To651Upgrader.ts
+++ b/src/logic/project/upgraders/From650To651Upgrader.ts
@@ -20,7 +20,7 @@ import { DEFAULT_API_BASE_URL, DEFAULT_BATCH_SIZE } from "@/logic/Constants";
  *
  * @author Pieter Verschaffelt
  */
-export class From640To651Upgrader implements ProjectUpgrader {
+export class From650To651Upgrader implements ProjectUpgrader {
     public readonly name = "From 6.4.0 to 6.5.1";
 
     public async canUpgrade(zippedProject: JSZip): Promise<boolean> {
@@ -120,17 +120,35 @@ export class From640To651Upgrader implements ProjectUpgrader {
 
         for (let i = 0; i < sequences.length; i += DEFAULT_BATCH_SIZE) {
             const batch = sequences.slice(i, i + DEFAULT_BATCH_SIZE);
-            const response = await fetch(`${DEFAULT_API_BASE_URL}/mpa/pept2data`, {
-                method: "POST",
-                body: JSON.stringify({
-                    peptides: batch,
-                    equate_il: equate,
-                    report_taxa: false
-                }),
-                headers: { "Content-Type": "application/json" }
-            }).then(r => r.json());
 
-            for (const peptide of response.peptides ?? []) {
+            let response: Response;
+            try {
+                response = await fetch(`${DEFAULT_API_BASE_URL}/mpa/pept2data`, {
+                    method: "POST",
+                    body: JSON.stringify({
+                        peptides: batch,
+                        equate_il: equate,
+                        report_taxa: false
+                    }),
+                    headers: { "Content-Type": "application/json" }
+                });
+            } catch {
+                throw new Error(
+                    "Could not reach the Unipept API while upgrading this project. " +
+                    "Please check your internet connection and try opening the project again."
+                );
+            }
+
+            if (!response.ok) {
+                throw new Error(
+                    `The Unipept API returned an error (HTTP ${response.status}) while upgrading this project. ` +
+                    "Please try again later."
+                );
+            }
+
+            const json = await response.json();
+
+            for (const peptide of json.peptides ?? []) {
                 result.set(peptide.sequence, {
                     crap_filtered: peptide.crap_filtered ?? false,
                     cutoff_used: peptide.cutoff_used ?? false

--- a/src/store/SingleAnalysisStore.ts
+++ b/src/store/SingleAnalysisStore.ts
@@ -105,7 +105,7 @@ const useSingleAnalysisStore = (
     // ===============================================================
     // ======================== PROCESSORS ===========================
     // ===============================================================
-    const { peptideData: peptideToData, process: processPept2Filtered } = usePept2filtered();
+    const { peptideData: peptideToData, crapFilteredPeptides, process: processPept2Filtered } = usePept2filtered();
 
     const { databaseVersion, process: processMetadata } = useMetaData();
     const { countTable: peptidesTable, process: processPeptides } = usePeptideProcessor();
@@ -165,7 +165,7 @@ const useSingleAnalysisStore = (
                     lastAnalysed.value = new Date();
                 }
 
-                processPeptideTrust(peptidesTable!.value!, peptideToData.value!);
+                processPeptideTrust(peptidesTable!.value!, peptideToData.value!, crapFilteredPeptides.value);
 
                 await processLca(peptidesTable.value!, peptideToData.value!);
                 await processEc(peptidesTable!.value!, peptideToData.value!, functionalFilter.value!);

--- a/src/store/UnipeptAnalysisStore.ts
+++ b/src/store/UnipeptAnalysisStore.ts
@@ -14,6 +14,7 @@ interface StoreValue {
     lastAccessed: number;
     totalPeptides: number;
     project: Blob;
+    upgradeError?: string | null;
 }
 
 const useUnipeptAnalysisStore = defineStore('PersistedAnalysisStore', () => {
@@ -37,7 +38,8 @@ const useUnipeptAnalysisStore = defineStore('PersistedAnalysisStore', () => {
             return {
                 name: key,
                 totalPeptides: value?.totalPeptides || 0,
-                lastAccessed: new Date(value!.lastAccessed)
+                lastAccessed: new Date(value!.lastAccessed),
+                upgradeError: value?.upgradeError || null
             };
         }));
     }
@@ -56,16 +58,23 @@ const useUnipeptAnalysisStore = defineStore('PersistedAnalysisStore', () => {
     const loadProjectFromStorage = async (projectName: string) => {
         const value: StoreValue | null = await store.getItem(projectName);
         if (value !== null) {
+            const processedImport = await blobToStore(value.project).catch(async (e: unknown) => {
+                const message = e instanceof Error ? e.message : String(e);
+                await store.setItem(projectName, { ...value, upgradeError: message });
+                throw e;
+            });
+
+            if (value.upgradeError) {
+                await store.setItem(projectName, { ...value, upgradeError: null });
+            }
+
             appState.clear();
             project.clear();
-
-            const processedImport = await blobToStore(value.project);
-
             project.setImportedData(processedImport.project);
             project.setName(projectName);
             project.setDemoMode(false);
             appState.setImportedData(processedImport.appState, project);
-            
+
             // Track project loading
             const analyticsCommunicator = new AnalyticsCommunicator();
             analyticsCommunicator.logLoadProjectFromStorage();
@@ -73,11 +82,10 @@ const useUnipeptAnalysisStore = defineStore('PersistedAnalysisStore', () => {
     }
 
     const loadProjectFromFile = async (projectName: string, file: File) => {
-        appState.clear();
-        project.clear();
-
         const processedImport = await blobToStore(file);
 
+        appState.clear();
+        project.clear();
         project.setImportedData(processedImport.project);
         project.setName(projectName);
         project.setDemoMode(false);

--- a/src/store/UnipeptAnalysisStore.ts
+++ b/src/store/UnipeptAnalysisStore.ts
@@ -24,7 +24,7 @@ const useUnipeptAnalysisStore = defineStore('PersistedAnalysisStore', () => {
     });
 
     const { process: storeToBlob } = useProjectExport();
-    const { process: blobToStore } = useProjectImport();
+    const { process: blobToStore, status: importStatus } = useProjectImport();
 
     const project = useProjectAnalysisStore();
     const customDatabases = useCustomFilterStore();
@@ -147,6 +147,7 @@ const useUnipeptAnalysisStore = defineStore('PersistedAnalysisStore', () => {
 
     return {
         project,
+        importStatus,
 
         getProjects,
         loadNewProject,

--- a/src/types/PeptideTrust.ts
+++ b/src/types/PeptideTrust.ts
@@ -1,5 +1,6 @@
 export default interface PeptideTrust {
     missedPeptides: string[],
+    crapFilteredPeptides: string[],
     matchedPeptides: number,
     searchedPeptides: number
 }


### PR DESCRIPTION
This PR provides a fix for #1839. Instead of hiding that a peptide's matches were cutoff, this is now explicitly reported to the user in both the "single peptide analysis" and "metaproteomics peptide analysis".

An alert is shown in the summary of the single peptide analysis. For the metaproteomics analysis, I have added an extra column to the analysis summary table. There is also a tooltip that's shown when the user hovers over the icons in this column which explains what this match exceeded means.

**Screenshot for SPA:**
<img width="1383" height="306" alt="image" src="https://github.com/user-attachments/assets/9950ac9f-9736-4fd6-94d2-db8aab5c0c56" />

**Screenshot for MPA:**
<img width="1366" height="671" alt="image" src="https://github.com/user-attachments/assets/c042e334-c3a2-492b-acad-d2f82dbd256e" />