### PR TITLE
Make navbar in documentation pages sticky

### DIFF
--- a/src/components/pages/features/APIPage.vue
+++ b/src/components/pages/features/APIPage.vue
@@ -10,6 +10,7 @@
             </v-col>
             <v-col
                 class="order-sm-0 order-lg-1"
+                style="position: sticky; top: calc(var(--v-layout-top, 0px) + 16px); align-self: flex-start;"
                 sm="12"
                 lg="2"
             >

--- a/src/components/pages/features/CLIPage.vue
+++ b/src/components/pages/features/CLIPage.vue
@@ -10,6 +10,7 @@
             </v-col>
             <v-col
                 class="order-sm-0 order-lg-1"
+                style="position: sticky; top: calc(var(--v-layout-top, 0px) + 16px); align-self: flex-start;"
                 sm="12"
                 lg="2"
             >

--- a/src/components/pages/features/DesktopPage.vue
+++ b/src/components/pages/features/DesktopPage.vue
@@ -10,6 +10,7 @@
             </v-col>
             <v-col
                 class="order-sm-0 order-lg-1"
+                style="position: sticky; top: calc(var(--v-layout-top, 0px) + 16px); align-self: flex-start;"
                 sm="12"
                 lg="2"
             >

--- a/src/components/pages/features/MetagenomicsPage.vue
+++ b/src/components/pages/features/MetagenomicsPage.vue
@@ -10,6 +10,7 @@
             </v-col>
             <v-col
                 class="order-sm-0 order-lg-1"
+                style="position: sticky; top: calc(var(--v-layout-top, 0px) + 16px); align-self: flex-start;"
                 sm="12"
                 lg="2"
             >


### PR DESCRIPTION
This PR implements a fix for #1550. The navbar is now sticky and follows the scroll of the user.