### PR TITLE
Add reprocessed PRIDE datasets as project source

### DIFF
--- a/src/components/analysis/multi/ReprocessedProjectCard.vue
+++ b/src/components/analysis/multi/ReprocessedProjectCard.vue
@@ -1,0 +1,83 @@
+<template>
+    <v-unipept-card :disabled="disabled">
+        <v-card-title>
+            <h2 class="mt-2" style="white-space: normal;">Open a reprocessed PRIDE Project</h2>
+        </v-card-title>
+
+        <v-card-text>
+            <p>Open a dataset we've already preprocessed from the PRIDE repository.</p>
+
+            <v-text-field
+                v-model="search"
+                class="mt-3"
+                density="compact"
+                variant="outlined"
+                hide-details
+                clearable
+                prepend-inner-icon="mdi-magnify"
+                autocomplete="off"
+                placeholder="Search dataset by PXD accession"
+            />
+
+            <div
+                v-if="loading"
+                class="d-flex justify-center my-5"
+            >
+                <v-progress-circular color="primary" indeterminate />
+            </div>
+
+            <v-list
+                v-else
+                class="mt-2"
+                style="max-height: 300px; overflow-y: auto;"
+                density="compact"
+            >
+                <v-list-item
+                    v-for="accession in filtered"
+                    :key="accession"
+                    :title="accession"
+                    rounded="lg"
+                    @click="emits('select', accession)"
+                >
+                    <template #prepend>
+                        <v-avatar color="primary">
+                            <v-icon icon="mdi-database" />
+                        </v-avatar>
+                    </template>
+                </v-list-item>
+
+                <v-list-item v-if="filtered.length === 0">
+                    <span class="text-medium-emphasis">No datasets found.</span>
+                </v-list-item>
+            </v-list>
+        </v-card-text>
+    </v-unipept-card>
+</template>
+
+<script setup lang="ts">
+import {computed, ref} from "vue";
+
+const {accessions, loading = false, disabled = false} = defineProps<{
+    accessions: string[],
+    loading?: boolean,
+    disabled?: boolean
+}>();
+
+const emits = defineEmits<{
+    (e: "select", accession: string): void;
+}>();
+
+const search = ref("");
+
+const filtered = computed(() => {
+    const term = (search.value ?? "").trim().toLowerCase();
+    if (term.length === 0) {
+        return accessions;
+    }
+    return accessions.filter(accession => accession.toLowerCase().includes(term));
+});
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/analysis/multi/ReprocessedProjectCard.vue
+++ b/src/components/analysis/multi/ReprocessedProjectCard.vue
@@ -44,6 +44,9 @@
                             <v-icon icon="mdi-database" />
                         </v-avatar>
                     </template>
+                    <template #append>
+                        <v-icon icon="mdi-chevron-right" />
+                    </template>
                 </v-list-item>
 
                 <v-list-item v-if="filtered.length === 0">

--- a/src/components/analysis/multi/ReprocessedProjectCard.vue
+++ b/src/components/analysis/multi/ReprocessedProjectCard.vue
@@ -5,7 +5,50 @@
         </v-card-title>
 
         <v-card-text>
-            <p>Open a dataset we've already preprocessed from the PRIDE repository.</p>
+            <p>
+                Reprocessed datasets are public metaproteomics datasets from PRIDE whose raw mass
+                spectrometry data were reanalysed with a standardized Sage and MS²Rescore workflow.
+                Because of this consistent workflow, the results shown in Unipept may differ from
+                those reported in the original publications.
+            </p>
+
+            <v-expand-transition>
+                <div v-if="showDetails" class="text-medium-emphasis">
+                    <p class="mt-2">
+                        Reprocessed datasets are public metaproteomics datasets, available on PRIDE,
+                        for which the original raw mass spectrometry data were analysed again using a
+                        standardized workflow. Instead of directly reusing the peptide identifications
+                        reported in the original publication, the spectra were searched again using
+                        Sage and MS²Rescore
+                        (<a href="https://doi.org/10.1101/2025.02.17.638783" target="_blank" rel="noopener">doi:10.1101/2025.02.17.638783v2</a>).
+                    </p>
+                    <p class="mt-2">
+                        At this stage, only human gut datasets have been reprocessed. These datasets
+                        were searched against the UHGP v2.0.2 protein catalogue clustered at 90% amino
+                        acid identity, concatenated with the human reference proteome and the cRAP
+                        contaminant database. Searches allowed up to two missed cleavages, with a
+                        precursor mass tolerance of 20 ppm and a fragment mass tolerance of 20 ppm.
+                        Carbamidomethylation of cysteine was set as a fixed modification, while
+                        methionine oxidation and protein N-terminal acetylation were included as
+                        variable modifications.
+                    </p>
+                    <p class="mt-2">
+                        Because these datasets were reprocessed with a consistent workflow, database,
+                        and search strategy, the results shown in Unipept may differ from those
+                        reported in the original publications.
+                    </p>
+                </div>
+            </v-expand-transition>
+
+            <v-btn
+                class="px-0"
+                variant="text"
+                color="primary"
+                density="compact"
+                :append-icon="showDetails ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+                :text="showDetails ? 'Show less' : 'Learn more'"
+                @click="showDetails = !showDetails"
+            />
 
             <v-text-field
                 v-model="search"
@@ -71,6 +114,7 @@ const emits = defineEmits<{
 }>();
 
 const search = ref("");
+const showDetails = ref(false);
 
 const filtered = computed(() => {
     const term = (search.value ?? "").trim().toLowerCase();

--- a/src/components/pages/features/analysis/MetaproteomeHomePage.vue
+++ b/src/components/pages/features/analysis/MetaproteomeHomePage.vue
@@ -31,7 +31,7 @@
                     <reprocessed-project-card
                         class="mt-5"
                         :accessions="reprocessedAccessions"
-                        :loading="loadingAccessions"
+                        :loading="loadingAccessions || loadingReprocessed"
                         :disabled="loadingProject || loadingDemoProject || loadingReprocessed || loadingAccessions"
                         @select="reprocessedAnalyze"
                     />

--- a/src/components/pages/features/analysis/MetaproteomeHomePage.vue
+++ b/src/components/pages/features/analysis/MetaproteomeHomePage.vue
@@ -16,16 +16,24 @@
             <v-col cols="12" md="6">
                 <div ref="firstColumn">
                     <quick-analysis-card
-                        :disabled="loadingProject || loadingDemoProject"
+                        :disabled="loadingProject || loadingDemoProject || loadingReprocessed"
                         @analyze="quickAnalyze"
                     />
 
                     <demo-analysis-card
                         class="mt-5"
                         :loading="loadingDemoProject"
-                        :disabled="loadingProject || loadingSampleData || loadingDemoProject"
+                        :disabled="loadingProject || loadingSampleData || loadingDemoProject || loadingReprocessed"
                         :samples="sampleDataStore.samples"
                         @select="demoAnalyze"
+                    />
+
+                    <reprocessed-project-card
+                        class="mt-5"
+                        :accessions="reprocessedAccessions"
+                        :loading="loadingAccessions"
+                        :disabled="loadingProject || loadingDemoProject || loadingReprocessed || loadingAccessions"
+                        @select="reprocessedAnalyze"
                     />
                 </div>
             </v-col>
@@ -34,7 +42,7 @@
                 <div ref="topCard">
                     <new-analysis-card
                         :projects="projects"
-                        :disabled="loadingProject || loadingDemoProject"
+                        :disabled="loadingProject || loadingDemoProject || loadingReprocessed"
                         @project:new="advancedAnalyze"
                     />
                 </div>
@@ -43,7 +51,7 @@
                     class="mt-5"
                     :height="bottomCardHeight"
                     :projects="projects"
-                    :disabled="loadingProject || loadingDemoProject"
+                    :disabled="loadingProject || loadingDemoProject || loadingReprocessed"
                     :loading="loadingProject"
                     :loading-message="importStatus"
                     @open="loadFromIndexedDB"
@@ -66,6 +74,8 @@ import {AnalysisConfig} from "@/store/AnalysisConfig";
 import useUnipeptAnalysisStore from "@/store/UnipeptAnalysisStore";
 import NewAnalysisCard from "@/components/analysis/multi/NewAnalysisCard.vue";
 import RecentAnalysisCard from "@/components/analysis/multi/RecentAnalysisCard.vue";
+import ReprocessedProjectCard from "@/components/analysis/multi/ReprocessedProjectCard.vue";
+import useReprocessedProjects from "@/composables/communication/reprocessed/useReprocessedProjects";
 import {useElementBounding} from "@vueuse/core";
 import {storeToRefs} from "pinia";
 
@@ -80,10 +90,12 @@ const {
     loadProjectFromStorage,
     loadProjectFromFile,
     loadProjectFromSample,
+    loadProjectFromReprocessed,
     loadProjectFromPeptides,
     deleteProject
 } = store;
 const sampleDataStore = useSampleDataStore();
+const { loadAccessions, loadProjectFiles } = useReprocessedProjects();
 
 const firstColumn = useTemplateRef("firstColumn");
 const { height: firstColumnHeight } = useElementBounding(firstColumn);
@@ -94,6 +106,10 @@ const bottomCardHeight = computed(() => firstColumnHeight.value - topCardHeight.
 const loadingSampleData: Ref<boolean> = ref(true);
 const loadingProject: Ref<boolean> = ref(false);
 const loadingDemoProject: Ref<boolean> = ref(false);
+const loadingAccessions: Ref<boolean> = ref(true);
+const loadingReprocessed: Ref<boolean> = ref(false);
+
+const reprocessedAccessions = ref<string[]>([]);
 
 const upgradeError: Ref<string | null> = ref(null);
 const showUpgradeError = ref(false);
@@ -157,6 +173,21 @@ const demoAnalyze = async (sample: SampleData) => {
     await startAnalysis();
 }
 
+const reprocessedAnalyze = async (accession: string) => {
+    loadingReprocessed.value = true;
+    try {
+        const files = await loadProjectFiles(accession);
+        await loadProjectFromReprocessed(accession, files);
+        await router.push({ name: "mpaSingle" });
+        await startAnalysis();
+    } catch (e) {
+        upgradeError.value = "Failed to open this reprocessed project. Please check your internet connection and try again.";
+        showUpgradeError.value = true;
+    } finally {
+        loadingReprocessed.value = false;
+    }
+}
+
 const startAnalysis = async () => {
     for (const group of project.groups) {
         for (const analysis of group.analyses) {
@@ -175,8 +206,15 @@ const startImport = async () => {
 
 onMounted(async () => {
     projects.value = await getProjects();
+
     loadingSampleData.value = true;
-    await sampleDataStore.loadSampleData();
+    loadingAccessions.value = true;
+    const [, accessions] = await Promise.all([
+        sampleDataStore.loadSampleData(),
+        loadAccessions().catch(() => [])
+    ]);
     loadingSampleData.value = false;
+    reprocessedAccessions.value = accessions;
+    loadingAccessions.value = false;
 })
 </script>

--- a/src/components/pages/features/analysis/MetaproteomeHomePage.vue
+++ b/src/components/pages/features/analysis/MetaproteomeHomePage.vue
@@ -95,7 +95,7 @@ const {
     deleteProject
 } = store;
 const sampleDataStore = useSampleDataStore();
-const { loadAccessions, loadProjectFiles } = useReprocessedProjects();
+const { loadReprocessedAccessions, loadReprocessedProjectFiles } = useReprocessedProjects();
 
 const firstColumn = useTemplateRef("firstColumn");
 const { height: firstColumnHeight } = useElementBounding(firstColumn);
@@ -176,7 +176,7 @@ const demoAnalyze = async (sample: SampleData) => {
 const reprocessedAnalyze = async (accession: string) => {
     loadingReprocessed.value = true;
     try {
-        const files = await loadProjectFiles(accession);
+        const files = await loadReprocessedProjectFiles(accession);
         await loadProjectFromReprocessed(accession, files);
         await router.push({ name: "mpaSingle" });
         await startAnalysis();
@@ -211,7 +211,7 @@ onMounted(async () => {
     loadingAccessions.value = true;
     const [, accessions] = await Promise.all([
         sampleDataStore.loadSampleData(),
-        loadAccessions().catch(() => [])
+        loadReprocessedAccessions().catch(() => [])
     ]);
     loadingSampleData.value = false;
     reprocessedAccessions.value = accessions;

--- a/src/composables/communication/reprocessed/useReprocessedProjects.ts
+++ b/src/composables/communication/reprocessed/useReprocessedProjects.ts
@@ -1,5 +1,7 @@
 import NetworkUtils from "@/logic/communicators/NetworkUtils";
 import {DEFAULT_REPROCESSED_PROJECTS_BASE_URL} from "@/logic/Constants";
+import useAsyncWebWorker from "@/composables/useAsyncWebWorker";
+import ReprocessedProjectLoaderWorker from "./workers/reprocessedProjectLoader.worker.ts?worker";
 
 export interface ReprocessedFile {
     name: string;                      // e.g. "S061.tsv"
@@ -7,54 +9,47 @@ export interface ReprocessedFile {
     intensities: Map<string, number>;  // peptide -> score
 }
 
+export interface ReprocessedLoaderData {
+    accession: string;
+    baseUrl: string;
+}
+
+const EXCLUDED_ACCESSIONS = new Set<string>([
+    "PXD003527",
+    "PXD016298",
+    "PXD017035",
+    "PXD007220",
+    "PXD015757",
+    "PXD020005",
+    "PXD035496",
+    "PXD036037",
+    "PXD048273",
+    "PXD046928",
+    "PXD006129",
+    "PXD011735",
+    "PXD009564",
+    "PXD036445",
+    "PXD024291",
+    "PXD057056",
+    "PXD017059",
+]);
+
 export default function useReprocessedProjects(
     baseUrl = DEFAULT_REPROCESSED_PROJECTS_BASE_URL,
 ) {
+    const { post } = useAsyncWebWorker<ReprocessedLoaderData, ReprocessedFile[]>(
+        () => new ReprocessedProjectLoaderWorker()
+    );
+
     const loadReprocessedAccessions = async (): Promise<string[]> => {
         const response = await NetworkUtils.getJSON(`${baseUrl}/projects.json`);
-        return response.map((entry: { accession: string }) => entry.accession);
-    }
-
-    const loadFileIndex = async (accession: string): Promise<string[]> => {
-        const response = await NetworkUtils.getJSON(`${baseUrl}/${accession}/files.json`);
-        return response.map((entry: { result_file: string }) => entry.result_file);
-    }
-
-    const loadFile = async (accession: string, fileName: string): Promise<ReprocessedFile> => {
-        const text = await NetworkUtils.getText(`${baseUrl}/${accession}/${fileName}`);
-
-        const peptides: string[] = [];
-        const intensities = new Map<string, number>();
-
-        for (const line of text.split("\n")) {
-            const trimmed = line.trim();
-            if (trimmed.length === 0) {
-                continue;
-            }
-
-            const [peptide, score] = trimmed.split("\t");
-            if (!peptide) {
-                continue;
-            }
-
-            peptides.push(peptide);
-
-            const parsedScore = parseFloat(score);
-            if (!isNaN(parsedScore)) {
-                intensities.set(peptide, parsedScore);
-            }
-        }
-
-        return {
-            name: fileName,
-            rawPeptides: peptides.join("\n"),
-            intensities
-        };
+        return response
+            .map((entry: { accession: string }) => entry.accession)
+            .filter((accession: string) => !EXCLUDED_ACCESSIONS.has(accession));
     }
 
     const loadReprocessedProjectFiles = async (accession: string): Promise<ReprocessedFile[]> => {
-        const fileNames = await loadFileIndex(accession);
-        return Promise.all(fileNames.map(fileName => loadFile(accession, fileName)));
+        return await post({ accession, baseUrl });
     }
 
     return {

--- a/src/composables/communication/reprocessed/useReprocessedProjects.ts
+++ b/src/composables/communication/reprocessed/useReprocessedProjects.ts
@@ -10,7 +10,7 @@ export interface ReprocessedFile {
 export default function useReprocessedProjects(
     baseUrl = DEFAULT_REPROCESSED_PROJECTS_BASE_URL,
 ) {
-    const loadAccessions = async (): Promise<string[]> => {
+    const loadReprocessedAccessions = async (): Promise<string[]> => {
         const response = await NetworkUtils.getJSON(`${baseUrl}/projects.json`);
         return response.map((entry: { accession: string }) => entry.accession);
     }
@@ -52,13 +52,13 @@ export default function useReprocessedProjects(
         };
     }
 
-    const loadProjectFiles = async (accession: string): Promise<ReprocessedFile[]> => {
+    const loadReprocessedProjectFiles = async (accession: string): Promise<ReprocessedFile[]> => {
         const fileNames = await loadFileIndex(accession);
         return Promise.all(fileNames.map(fileName => loadFile(accession, fileName)));
     }
 
     return {
-        loadAccessions,
-        loadProjectFiles
+        loadReprocessedAccessions,
+        loadReprocessedProjectFiles
     }
 }

--- a/src/composables/communication/reprocessed/useReprocessedProjects.ts
+++ b/src/composables/communication/reprocessed/useReprocessedProjects.ts
@@ -1,0 +1,64 @@
+import NetworkUtils from "@/logic/communicators/NetworkUtils";
+import {DEFAULT_REPROCESSED_PROJECTS_BASE_URL} from "@/logic/Constants";
+
+export interface ReprocessedFile {
+    name: string;                      // e.g. "S061.tsv"
+    rawPeptides: string;               // peptides joined by "\n"
+    intensities: Map<string, number>;  // peptide -> score
+}
+
+export default function useReprocessedProjects(
+    baseUrl = DEFAULT_REPROCESSED_PROJECTS_BASE_URL,
+) {
+    const loadAccessions = async (): Promise<string[]> => {
+        const response = await NetworkUtils.getJSON(`${baseUrl}/projects.json`);
+        return response.map((entry: { accession: string }) => entry.accession);
+    }
+
+    const loadFileIndex = async (accession: string): Promise<string[]> => {
+        const response = await NetworkUtils.getJSON(`${baseUrl}/${accession}/files.json`);
+        return response.map((entry: { result_file: string }) => entry.result_file);
+    }
+
+    const loadFile = async (accession: string, fileName: string): Promise<ReprocessedFile> => {
+        const text = await NetworkUtils.getText(`${baseUrl}/${accession}/${fileName}`);
+
+        const peptides: string[] = [];
+        const intensities = new Map<string, number>();
+
+        for (const line of text.split("\n")) {
+            const trimmed = line.trim();
+            if (trimmed.length === 0) {
+                continue;
+            }
+
+            const [peptide, score] = trimmed.split("\t");
+            if (!peptide) {
+                continue;
+            }
+
+            peptides.push(peptide);
+
+            const parsedScore = parseFloat(score);
+            if (!isNaN(parsedScore)) {
+                intensities.set(peptide, parsedScore);
+            }
+        }
+
+        return {
+            name: fileName,
+            rawPeptides: peptides.join("\n"),
+            intensities
+        };
+    }
+
+    const loadProjectFiles = async (accession: string): Promise<ReprocessedFile[]> => {
+        const fileNames = await loadFileIndex(accession);
+        return Promise.all(fileNames.map(fileName => loadFile(accession, fileName)));
+    }
+
+    return {
+        loadAccessions,
+        loadProjectFiles
+    }
+}

--- a/src/composables/communication/reprocessed/workers/reprocessedProjectLoader.worker.ts
+++ b/src/composables/communication/reprocessed/workers/reprocessedProjectLoader.worker.ts
@@ -1,0 +1,52 @@
+import NetworkUtils from "@/logic/communicators/NetworkUtils";
+import type {ReprocessedFile, ReprocessedLoaderData} from "../useReprocessedProjects";
+
+self.onunhandledrejection = (event) => {
+    throw event.reason;
+};
+
+self.onmessage = async (event) => {
+    self.postMessage(await process(event.data));
+}
+
+const process = async ({accession, baseUrl}: ReprocessedLoaderData): Promise<ReprocessedFile[]> => {
+    const fileNames = await loadFileIndex(baseUrl, accession);
+    return Promise.all(fileNames.map(fileName => loadFile(baseUrl, accession, fileName)));
+}
+
+const loadFileIndex = async (baseUrl: string, accession: string): Promise<string[]> => {
+    const response = await NetworkUtils.getJSON(`${baseUrl}/${accession}/files.json`);
+    return response.map((entry: { result_file: string }) => entry.result_file);
+}
+
+const loadFile = async (baseUrl: string, accession: string, fileName: string): Promise<ReprocessedFile> => {
+    const text = await NetworkUtils.getText(`${baseUrl}/${accession}/${fileName}`);
+
+    const peptides: string[] = [];
+    const intensities = new Map<string, number>();
+
+    for (const line of text.split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed.length === 0) {
+            continue;
+        }
+
+        const [peptide, score] = trimmed.split("\t");
+        if (!peptide) {
+            continue;
+        }
+
+        peptides.push(peptide);
+
+        const parsedScore = parseFloat(score);
+        if (!isNaN(parsedScore)) {
+            intensities.set(peptide, parsedScore);
+        }
+    }
+
+    return {
+        name: fileName,
+        rawPeptides: peptides.join("\n"),
+        intensities
+    };
+}

--- a/src/logic/Constants.ts
+++ b/src/logic/Constants.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_API_BASE_URL = "https://api.unipept.ugent.be";
 export const DEFAULT_PATHWAY_PILOT_BASE_URL = "https://pathwaypilot.ugent.be/api";
+export const DEFAULT_REPROCESSED_PROJECTS_BASE_URL = "https://genesis.ugent.be/uvpublicdata/metaproteomics_results";
 export const DEFAULT_ONTOLOGY_BATCH_SIZE = 100;
 export const DEFAULT_BATCH_SIZE = 200;
 

--- a/src/logic/communicators/NetworkUtils.ts
+++ b/src/logic/communicators/NetworkUtils.ts
@@ -5,6 +5,20 @@ export default class NetworkUtils {
     }
 
     /**
+     * Fetches a URL and returns its body as plain text. Throws if the response is not OK.
+     *
+     * @param url The url to fetch.
+     * @return A promise containing the response body as a string.
+     */
+    public static async getText(url: string): Promise<string> {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`Request failed: ${response.status} ${response.statusText} (${url})`);
+        }
+        return response.text();
+    }
+
+    /**
      * Posts data to a URL as JSON and returns a promise containing the parsed (JSON) response.
      *
      * @param url The url to which we want to send the request.

--- a/src/logic/communicators/analytics/AnalyticsCommunicator.ts
+++ b/src/logic/communicators/analytics/AnalyticsCommunicator.ts
@@ -33,6 +33,10 @@ export default class AnalyticsCommunicator {
         this.logEvent('load_demo_project');
     }
 
+    public logLoadReprocessedProject() {
+        this.logEvent('load_reprocessed_project');
+    }
+
     public logQuickAnalysis() {
         this.logEvent('quick_analysis');
     }

--- a/src/store/UnipeptAnalysisStore.ts
+++ b/src/store/UnipeptAnalysisStore.ts
@@ -2,6 +2,7 @@ import {defineStore} from "pinia";
 import useProjectAnalysisStore from "@/store/ProjectAnalysisStore";
 import localforage from "localforage";
 import {SampleData} from "@/composables/communication/unipept/useSampleData";
+import {ReprocessedFile} from "@/composables/communication/reprocessed/useReprocessedProjects";
 import {AnalysisConfig} from "@/store/AnalysisConfig";
 import useCustomFilterStore, {UNIPROT_ID} from "@/store/CustomFilterStore";
 import useProjectExport from "@/composables/useProjectExport";
@@ -16,6 +17,14 @@ interface StoreValue {
     project: Blob;
     upgradeError?: string | null;
 }
+
+// Default analysis configuration shared by the preset (demo / reprocessed) project loaders.
+const DEMO_ANALYSIS_CONFIG: AnalysisConfig = {
+    equate: true,
+    filter: true,
+    useCrap: false,
+    database: UNIPROT_ID
+};
 
 const useUnipeptAnalysisStore = defineStore('PersistedAnalysisStore', () => {
     const store = localforage.createInstance({
@@ -104,17 +113,28 @@ const useUnipeptAnalysisStore = defineStore('PersistedAnalysisStore', () => {
         project.setDemoMode(true);
         const groupId = project.addGroup(sample.environment);
         for (const dataset of sample.datasets) {
-            project.getGroup(groupId)?.addAnalysis(dataset.name, dataset.data.join('\n'), {
-                equate: true,
-                filter: true,
-                useCrap: false,
-                database: UNIPROT_ID
-            });
+            project.getGroup(groupId)?.addAnalysis(dataset.name, dataset.data.join('\n'), DEMO_ANALYSIS_CONFIG);
         }
         
         // Track demo project loading
         const analyticsCommunicator = new AnalyticsCommunicator();
         analyticsCommunicator.logLoadDemoProject();
+    }
+
+    const loadProjectFromReprocessed = async (accession: string, files: ReprocessedFile[]) => {
+        appState.clear();
+        project.clear();
+
+        project.setName(accession);
+        project.setDemoMode(true);
+        const groupId = project.addGroup(accession);
+        for (const file of files) {
+            project.getGroup(groupId)?.addAnalysis(file.name, file.rawPeptides, DEMO_ANALYSIS_CONFIG, file.intensities);
+        }
+
+        // Track reprocessed project loading
+        const analyticsCommunicator = new AnalyticsCommunicator();
+        analyticsCommunicator.logLoadReprocessedProject();
     }
 
     const loadProjectFromPeptides = async (rawPeptides: string, config: AnalysisConfig) => {
@@ -162,6 +182,7 @@ const useUnipeptAnalysisStore = defineStore('PersistedAnalysisStore', () => {
         loadProjectFromStorage,
         loadProjectFromFile,
         loadProjectFromSample,
+        loadProjectFromReprocessed,
         loadProjectFromPeptides,
         deleteProject
     }


### PR DESCRIPTION
This PR adds a new feature that allows users to load PRIDE datasets that have been reprocessed by CompOmics as Unipept projects. A new card has been added to the metaproteomics analysis homepage.

**Screenshot:**

<img width="499" height="521" alt="image" src="https://github.com/user-attachments/assets/9da510e1-bb21-40a1-bbfa-0dacde5e7fd0" />

