### PR TITLE
Update unipept-visualizations to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "peptonizer": "file:./peptonizer-v0.0.31.tgz",
     "pinia": "^3.0.4",
     "shared-memory-datastructures": "1.0.0-alpha.9",
-    "unipept-visualizations": "^2.2.5",
+    "unipept-visualizations": "^3.0.0",
     "vue": "^3.5.35",
     "vue-router": "^5.1.0",
     "vuedraggable": "^4.1.0",

--- a/src/components/results/taxonomic/TaxonomicBarplot.vue
+++ b/src/components/results/taxonomic/TaxonomicBarplot.vue
@@ -143,7 +143,6 @@
     barplotSettings.value.chart.padding.right = 30;
     barplotSettings.value.legend.padding.top = 40;
     barplotSettings.value.legend.padding.left = 20;
-    barplotSettings.value.height = 250 + 100 * props.analyses.length;
     barplotSettings.value.showBarLabel = props.analyses.length > 1;
     barplotSettings.value.barLabelWidth = 200;
     barplotSettings.value.displayMode = "relative";
@@ -228,17 +227,14 @@
                 items
             });
         }
-        barplotSettings.value.height = barplotSettings.value.barHeight * props.analyses.length + 100 + Math.ceil((taxonCount.value + 1) / 3) * 30;
         barData.value = createdBars;
     }
 
     onMounted(() => {
         const observer = new ResizeObserver(() => {
             containerWidth.value = barplotWrapper.value?.offsetWidth ?? 800;
-            // containerHeight.value = barplotWrapper.value?.offsetHeight ?? props.height;
 
             barplotSettings.value.width = containerWidth.value;
-            // barplotSettings.value.height = containerHeight.value;
         });
 
         if (barplotWrapper.value) {

--- a/src/components/results/taxonomic/Treeview.vue
+++ b/src/components/results/taxonomic/Treeview.vue
@@ -46,10 +46,7 @@ const visualizationObject = ref<UnipeptTreeview | undefined>(undefined);
 
 const downloadImageModalOpen = ref(false);
 
-// @ts-ignore We're accessing the private property element of UnipeptTreeview here, but this is the only way
-// we get access to a properly initialized SVG... We might have to consider adding a getter for this element
-// in a future version of the Unipept Visualizations library.
-const svg = computed(() => visualizationObject.value?.element.querySelector(":scope > svg"))
+const svg = computed(() => visualizationObject.value?.element.querySelector<SVGSVGElement>(":scope > svg"))
 
 const { isFullscreen, toggle } = useFullscreen(controls);
 const { width, height } = useElementSize(controls);

--- a/src/components/visualization/barplot/Barplot.vue
+++ b/src/components/visualization/barplot/Barplot.vue
@@ -117,7 +117,6 @@ onMounted(() => {
 watch([
     () => props.bars,
     () => props.settings.width,
-    () => props.settings.height,
     () => props.settings.showBarLabel,
     () => barLabelWidth.value
 ], () => {

--- a/src/components/visualization/barplot/Barplot.vue
+++ b/src/components/visualization/barplot/Barplot.vue
@@ -70,6 +70,16 @@ const startResizing = (event: MouseEvent) => {
     document.addEventListener('mouseup', onMouseUp);
 };
 
+let barplot: Barplot | undefined;
+
+/**
+ * The width handed to the barplot itself. When we render the bar labels, they sit beside the plot and eat into the
+ * width the container reports.
+ */
+const plotWidth = () => props.settings.showBarLabel
+    ? Math.max(0, props.settings.width - barLabelWidth.value - 12) // 12px for resizer and padding
+    : props.settings.width;
+
 const renderPlot = () => {
     const tooltipElements = document.getElementsByClassName("unipept-tooltip");
     for (let i = 0; i < tooltipElements.length; i++) {
@@ -98,16 +108,29 @@ const renderPlot = () => {
     if (props.settings.showBarLabel) {
         settings.showBarLabel = false;
         // We also need to adjust the width of the barplot itself because the container width now includes the labels
-        settings.width = Math.max(0, props.settings.width - barLabelWidth.value - 12); // 12px for resizer and padding
+        settings.width = plotWidth();
         settings.chart.padding.left = 0;
     }
 
     // Render barplot again
-    new Barplot(
+    barplot = new Barplot(
         barplotContainer.value,
         bars,
         settings
     );
+};
+
+/**
+ * A barplot copies the data and the settings it is given when it is constructed, so only a change that is purely a
+ * change of width can go through resize. Anything else has to build a new one.
+ */
+const resizePlot = () => {
+    if (!barplot || props.settings.width === 0) {
+        renderPlot();
+        return;
+    }
+
+    barplot.resize(plotWidth());
 };
 
 onMounted(() => {
@@ -116,11 +139,16 @@ onMounted(() => {
 
 watch([
     () => props.bars,
-    () => props.settings.width,
-    () => props.settings.showBarLabel,
-    () => barLabelWidth.value
+    () => props.settings.showBarLabel
 ], () => {
     renderPlot();
+});
+
+watch([
+    () => props.settings.width,
+    () => barLabelWidth.value
+], () => {
+    resizePlot();
 });
 </script>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3719,12 +3719,12 @@ uglify-js@^3.1.4:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-unipept-visualizations@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/unipept-visualizations/-/unipept-visualizations-2.2.5.tgz#e19de904dc7f237a42485b742b772bd99ef1ce4a"
-  integrity sha512-vM4ly90d6ld23qIU62Zqf4oPxccew/9R7Za20P3SFX6MfE4G4xfLafoTGarXnghg/gbvIjBRl6Iea2EA1HtG8w==
+unipept-visualizations@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unipept-visualizations/-/unipept-visualizations-3.0.0.tgz#879ad5ce5938bdcc4dc6f39fef84e57b4fe23ec1"
+  integrity sha512-qbue67xGio+fkDrowQDM8K68N4k0VB4dzQnoytsBtXTu14yaWRbHlGUQISLiu5FmKOMB2GSGjB2ouWBdzsusNA==
   dependencies:
-    d3 "^7.9.0"
+    "@types/d3" "^7.4.3"
 
 unique-filename@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This pull request updates `unipept-visualizations` from 2.2.5 to 3.0.0 and takes advantage of two things that changed in it.

## Neither breaking change in 3.0.0 affects this repository

The release has two breaking changes. I checked both against this codebase before bumping:

- **`d3` is no longer a runtime dependency of the library.** It is still bundled into the published file, but it is no longer installed transitively. This repository already declares `d3: ^7.9.0` itself, so nothing changes here.
- **Deep imports are gone**, because the library now declares an `exports` map. Every import here is from the package root (`import { Barplot } from "unipept-visualizations"`), so nothing changes here either. Worth noting `tsconfig.json` uses `moduleResolution: "Node"`, which ignores `exports` entirely and resolves through `main`/`types`; `yarn types:check` passes.

## The barplot sizes itself now

`TaxonomicBarplot.vue` was computing the barplot height by hand:

```js
barplotSettings.value.height = barplotSettings.value.barHeight * props.analyses.length + 100
    + Math.ceil((taxonCount.value + 1) / 3) * 30;
```

Bars times `barHeight`, plus a constant for the axis, plus an estimate of the legend rows. In 3.0.0 the barplot derives exactly that from its own layout and `height` is no longer read at all, so the calculation is removed along with the initial estimate above it and the two commented out `containerHeight` lines that went with them.

Measured against the real 3.0.0 build with this repository's own settings (`barHeight: 100`, `maxItems: 15`, the chart and legend padding set in `TaxonomicBarplot.vue`):

| analyses | old formula | 3.0.0 | delta |
| --- | --- | --- | --- |
| 1 | 380 | 345 | -35 |
| 2 | 480 | 445 | -35 |
| 5 | 780 | 745 | -35 |
| 12 | 1480 | 1445 | -35 |

A constant 35px at every size, so the plot loses a strip of empty space at the bottom and nothing else moves. Nothing is clipped: the old formula was an over-estimate, not an under-estimate.

`Barplot.vue` also stops watching `props.settings.height`, since nothing writes it any more and the library would ignore it if anything did. The watch on `props.bars` still drives the re-render.

## The treeview no longer reaches into a private field

`Treeview.vue` read the library's private `element` to find the rendered SVG:

```js
// @ts-ignore We're accessing the private property element of UnipeptTreeview here, but this is the only way
// we get access to a properly initialized SVG... We might have to consider adding a getter for this element
// in a future version of the Unipept Visualizations library.
```

`element` is public and readonly in 3.0.0, so the ignore is gone.

Removing it surfaced something the ignore had been hiding. With the error suppressed the expression fell back to `any`, so nobody had ever checked that `querySelector` returns `Element` while `<download-image>` asks for `SVGElement | HTMLElement`. Typing the query as `querySelector<SVGSVGElement>` fixes it properly. Note this is stricter than the sibling components, which cast with `as SVGElement` (`Sunburst.vue:71`); `vue-tsc` narrows through the `v-if`, so no cast is needed.

## The barplot is resized rather than rebuilt when only the width changes

`Barplot.vue` rebuilt the whole barplot on every watched change, including the container width and the bar label
width. 3.0.0 has `resize(width)`, so the width cases no longer need a teardown. The bar label width matters most here:
it is driven by a drag handle, so it fires continuously while the user drags.

The split is not arbitrary. A barplot copies its data and its settings when it is constructed, which I confirmed
against the published build:

```
instance picks up later settings mutations:  false
instance picks up later data mutations:      false
```

So `resize` is only valid for a change that is purely a change of width. `props.bars` and `props.settings.showBarLabel`
still build a new barplot, because the instance cannot see those.

The width handed to the barplot is not the container width when the bar labels are rendered beside it, so that
calculation moved into a `plotWidth()` helper that both paths use rather than being repeated.

Verified that the resize path produces markup identical to the render path it replaces, for both a container width
change and a bar label width change, with and without bar labels:

| showBarLabel | change | identical |
| --- | --- | --- |
| false | 800px -> 1200px | yes |
| false | label 200 -> 320 | yes |
| false | 1000px/250 -> 640px/90 | yes |
| true | 800px -> 1200px | yes |
| true | label 200 -> 320 | yes |
| true | 1000px/250 -> 640px/90 | yes |

**Manual testing instructions**
- Open a single metaproteomics analysis and check the taxonomic barplot renders, with the legend directly under the plot and no large gap below it.
- Open a comparative analysis with several samples and confirm the bars are all present and correctly spaced.
- Resize the window and confirm the barplot follows the container width.
- Drag the bar label resize handle on a comparative analysis and confirm the plot reflows smoothly and the bars stay correct.
- On the treeview, open the download dialog and export both SVG and PNG.

**Checklist**
- Tests: no new tests. The existing suite passes (51 tests), as do `yarn types:check`, `yarn lint` and `yarn build`.
- Docs: n/a
- Announcement: n/a, no user visible change beyond a slightly tighter barplot.
- AI: Claude Code made the change and verified it against the published 3.0.0 build.
