### PR TITLE
Bring the API documentation in line with the current API

### DIFF
--- a/src/components/pages/documentation/apidocs/APIDocsOverviewPage.vue
+++ b/src/components/pages/documentation/apidocs/APIDocsOverviewPage.vue
@@ -11,7 +11,7 @@
             🔁 <b>As a result, the V1 and V2 endpoints of the Unipept API now produce identical taxonomic results, and can be used interchangeably. The rank "superkingdom" is no longer available, and the ranks "domain" and "realm" have been introduced.</b>
             <br>
             <br>
-            Support for V1 of the Unipept API has been dropped, and all requests to V1 will automatically be redirected to V2.
+            Support for V1 of the Unipept API has been dropped. The V1 endpoints remain reachable, but they are served by the V2 implementation and return exactly the same responses.
         </v-alert>
 
         <h1 class="font-weight-light">

--- a/src/components/pages/documentation/apidocs/APIPept2EcPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2EcPage.vue
@@ -118,8 +118,9 @@
                 </li>
                 <li>
                     <inline-code>total_protein_count</inline-code>: the amount of proteins matched with the given peptide that carry
-                    at least one functional annotation. Note that this is lower than the total amount of matched proteins
-                    when some of the matches are unannotated.
+                    at least one functional annotation. This counts any annotation, so a protein carrying only a
+                    <initialism>GO</initialism>-term or an InterPro entry, and no <initialism>EC</initialism>-number, is included here too.
+                    Proteins matched with the peptide but carrying no functional annotation at all are not counted.
                 </li>
                 <li>
                     <inline-code>ec</inline-code>: A list of <initialism>JSON</initialism> objects that each represent an <initialism>EC</initialism>-number associated with the current peptide.

--- a/src/components/pages/documentation/apidocs/APIPept2EcPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2EcPage.vue
@@ -64,7 +64,7 @@
             </h3>
             <p>
                 <inline-code>equate_il</inline-code> is an optional parameter and can either be <inline-code>true</inline-code> or <inline-code>false</inline-code>.
-                When not set explicitly, the parameter defaults to <inline-code>false</inline-code>.
+                When not set explicitly, the parameter defaults to <inline-code>true</inline-code>.
                 When the parameter is set to <inline-code>true</inline-code>, isoleucine (I) and leucine (L) are equated when matching peptides to UniProt entries.
                 This setting is similar to checking the <i>Equate I and L</i> checkbox when performing a search with the <r-link
                     to="/tpa"
@@ -117,7 +117,9 @@
                     <inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff (default: 10,000 proteins) and the response was truncated; <inline-code>false</inline-code> otherwise.
                 </li>
                 <li>
-                    <inline-code>total_protein_count</inline-code>: total amount of proteins matched with the given peptide.
+                    <inline-code>total_protein_count</inline-code>: the amount of proteins matched with the given peptide that carry
+                    at least one functional annotation. Note that this is lower than the total amount of matched proteins
+                    when some of the matches are unannotated.
                 </li>
                 <li>
                     <inline-code>ec</inline-code>: A list of <initialism>JSON</initialism> objects that each represent an <initialism>EC</initialism>-number associated with the current peptide.
@@ -365,7 +367,7 @@ const response3 = ref({});
 const response4 = ref({});
 
 const input = ref("");
-const equate_il = ref(false);
+const equate_il = ref(true);
 const extra = ref(false);
 
 const tryItResponse = ref({});

--- a/src/components/pages/documentation/apidocs/APIPept2FunctPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2FunctPage.vue
@@ -115,8 +115,8 @@
                     <li><inline-code>peptide</inline-code>: the peptide that was searched for.</li>
                     <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff (default: 10,000 proteins) and the response was truncated; <inline-code>false</inline-code> otherwise.</li>
                     <li><inline-code>total_protein_count</inline-code>: the amount of proteins matched with the given peptide that carry
-                        at least one functional annotation. Note that this is lower than the total amount of matched proteins
-                        when some of the matches are unannotated.</li>
+                        at least one functional annotation. A protein carrying just one of the three annotation types is included
+                        here too. Proteins matched with the peptide but carrying no functional annotation at all are not counted.</li>
                     <li>
                         <inline-code>ec</inline-code>:
                         A list of <initialism>JSON</initialism> objects that each represent an <initialism>EC</initialism>-number associated with the current peptide.

--- a/src/components/pages/documentation/apidocs/APIPept2FunctPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2FunctPage.vue
@@ -60,7 +60,7 @@
                 equate_il
             </h3>
             <p>
-                <inline-code>equate_il</inline-code> is an optional parameter and can either be <inline-code>true</inline-code> or <inline-code>false</inline-code>. When not set explicitly, the parameter defaults to <inline-code>false</inline-code>.
+                <inline-code>equate_il</inline-code> is an optional parameter and can either be <inline-code>true</inline-code> or <inline-code>false</inline-code>. When not set explicitly, the parameter defaults to <inline-code>true</inline-code>.
                 When the parameter is set to <inline-code>true</inline-code>, isoleucine (I) and leucine (L) are equated when matching peptides to UniProt entries.
                 This setting is similar to checking the <i>Equate I and L</i> checkbox when performing a search with the <r-link
                     to="/tpa"
@@ -114,7 +114,9 @@
                 <ul class="my-3">
                     <li><inline-code>peptide</inline-code>: the peptide that was searched for.</li>
                     <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff (default: 10,000 proteins) and the response was truncated; <inline-code>false</inline-code> otherwise.</li>
-                    <li><inline-code>total_protein_count</inline-code>: total amount of proteins matched with the given peptide.</li>
+                    <li><inline-code>total_protein_count</inline-code>: the amount of proteins matched with the given peptide that carry
+                        at least one functional annotation. Note that this is lower than the total amount of matched proteins
+                        when some of the matches are unannotated.</li>
                     <li>
                         <inline-code>ec</inline-code>:
                         A list of <initialism>JSON</initialism> objects that each represent an <initialism>EC</initialism>-number associated with the current peptide.
@@ -445,7 +447,7 @@ const response4 = ref({});
 const response5 = ref({});
 
 const input = ref("");
-const equate_il = ref(false);
+const equate_il = ref(true);
 const extra = ref(false);
 const domains = ref(false);
 

--- a/src/components/pages/documentation/apidocs/APIPept2GoPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2GoPage.vue
@@ -63,7 +63,7 @@
             </h3>
             <p>
                 <inline-code>equate_il</inline-code> is an optional parameter and can either be <inline-code>true</inline-code> or <inline-code>false</inline-code>.
-                When not set explicitly, the parameter defaults to <inline-code>false</inline-code>.
+                When not set explicitly, the parameter defaults to <inline-code>true</inline-code>.
                 When the parameter is set to <inline-code>true</inline-code>, isoleucine (I) and leucine (L) are equated when matching peptides to UniProt entries.
                 This setting is similar to checking the <i>Equate I and L</i> checkbox when performing a search with the <r-link
                     to="/tpa"
@@ -122,7 +122,9 @@
                         <inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff (default: 10,000 proteins) and the response was truncated; <inline-code>false</inline-code> otherwise.
                     </li>
                     <li>
-                        <inline-code>total_protein_count</inline-code>: total amount of proteins matched with the given peptide.
+                        <inline-code>total_protein_count</inline-code>: the amount of proteins matched with the given peptide that carry
+                        at least one functional annotation. Note that this is lower than the total amount of matched proteins
+                        when some of the matches are unannotated.
                     </li>
                     <li>
                         <inline-code>go</inline-code>: A list of <initialism>JSON</initialism> objects that each represent a <initialism>GO</initialism>-term associated with the current peptide.
@@ -417,7 +419,7 @@ const response4 = ref({});
 const response5 = ref({});
 
 const input = ref("");
-const equate_il = ref(false);
+const equate_il = ref(true);
 const extra = ref(false);
 const domains = ref(false);
 

--- a/src/components/pages/documentation/apidocs/APIPept2GoPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2GoPage.vue
@@ -123,8 +123,9 @@
                     </li>
                     <li>
                         <inline-code>total_protein_count</inline-code>: the amount of proteins matched with the given peptide that carry
-                        at least one functional annotation. Note that this is lower than the total amount of matched proteins
-                        when some of the matches are unannotated.
+                        at least one functional annotation. This counts any annotation, so a protein carrying only an
+                        <initialism>EC</initialism>-number or an InterPro entry, and no <initialism>GO</initialism>-term, is included here too.
+                        Proteins matched with the peptide but carrying no functional annotation at all are not counted.
                     </li>
                     <li>
                         <inline-code>go</inline-code>: A list of <initialism>JSON</initialism> objects that each represent a <initialism>GO</initialism>-term associated with the current peptide.

--- a/src/components/pages/documentation/apidocs/APIPept2InterproPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2InterproPage.vue
@@ -63,7 +63,7 @@
             </h3>
             <p>
                 <inline-code>equate_il</inline-code> is an optional parameter and can either be <inline-code>true</inline-code> or <inline-code>false</inline-code>.
-                When not set explicitly, the parameter defaults to <inline-code>false</inline-code>.
+                When not set explicitly, the parameter defaults to <inline-code>true</inline-code>.
                 When the parameter is set to <inline-code>true</inline-code>, isoleucine (I) and leucine (L) are equated when matching peptides to UniProt entries.
                 This setting is similar to checking the <i>Equate I and L</i> checkbox when performing a search with the <r-link
                     to="/tpa"
@@ -116,7 +116,9 @@
             <ul class="my-3">
                 <li><inline-code>peptide</inline-code>: the peptide that was searched for.</li>
                 <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff (default: 10,000 proteins) and the response was truncated; <inline-code>false</inline-code> otherwise.</li>
-                <li><inline-code>total_protein_count</inline-code>: total amount of proteins matched with the given peptide.</li>
+                <li><inline-code>total_protein_count</inline-code>: the amount of proteins matched with the given peptide that carry
+                    at least one functional annotation. Note that this is lower than the total amount of matched proteins
+                    when some of the matches are unannotated.</li>
                 <li>
                     <inline-code>ipr</inline-code>:
                     A list of <initialism>JSON</initialism> objects that each represent an InterPro entry associated with
@@ -413,7 +415,7 @@ const response4 = ref({});
 const response5 = ref({});
 
 const input = ref("");
-const equate_il = ref(false);
+const equate_il = ref(true);
 const extra = ref(false);
 const domains = ref(false);
 

--- a/src/components/pages/documentation/apidocs/APIPept2InterproPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2InterproPage.vue
@@ -117,8 +117,9 @@
                 <li><inline-code>peptide</inline-code>: the peptide that was searched for.</li>
                 <li><inline-code>cutoff_used</inline-code>: <inline-code>true</inline-code> if the number of matched proteins exceeded the cutoff (default: 10,000 proteins) and the response was truncated; <inline-code>false</inline-code> otherwise.</li>
                 <li><inline-code>total_protein_count</inline-code>: the amount of proteins matched with the given peptide that carry
-                    at least one functional annotation. Note that this is lower than the total amount of matched proteins
-                    when some of the matches are unannotated.</li>
+                    at least one functional annotation. This counts any annotation, so a protein carrying only an
+                    <initialism>EC</initialism>-number or a <initialism>GO</initialism>-term, and no InterPro entry, is included here too.
+                    Proteins matched with the peptide but carrying no functional annotation at all are not counted.</li>
                 <li>
                     <inline-code>ipr</inline-code>:
                     A list of <initialism>JSON</initialism> objects that each represent an InterPro entry associated with

--- a/src/components/pages/documentation/apidocs/APIPept2LcaPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2LcaPage.vue
@@ -63,7 +63,7 @@
             </h3>
             <p>
                 <inline-code>equate_il</inline-code> is an optional parameter and can either be <inline-code>true</inline-code> or <inline-code>false</inline-code>.
-                When not set explicitly, the parameter defaults to <inline-code>false</inline-code>.
+                When not set explicitly, the parameter defaults to <inline-code>true</inline-code>.
                 When the parameter is set to <inline-code>true</inline-code>, isoleucine (I) and leucine (L) are equated when matching peptides to UniProt entries.
                 This setting is similar to checking the <i>Equate I and L</i> checkbox when performing a search with the <r-link
                     to="/tpa"
@@ -110,6 +110,18 @@
                     Do not use this parameter unless the extra information fields are needed.
                 </p>
             </static-alert>
+
+            <h3 class="font-weight-medium">
+                validate_taxa
+            </h3>
+            <p>
+                <inline-code>validate_taxa</inline-code> is an optional parameter and can either be <inline-code>true</inline-code> or <inline-code>false</inline-code>.
+                When not set explicitly, the parameter defaults to <inline-code>true</inline-code>.
+                When the parameter is set to <inline-code>true</inline-code>, taxa that are no longer valid in the <initialism>NCBI</initialism> taxonomy, as well as
+                taxa that carry no meaningful classification (such as <i>uncultured bacterium</i> or <i>Bacteria incertae sedis</i>), are left out of the
+                calculation. Setting it to <inline-code>false</inline-code> takes all taxa into account, which usually results in a less specific
+                lowest common ancestor.
+            </p>
         </header-body-card>
 
         <!-- Response Card -->
@@ -145,12 +157,10 @@
                 <li><inline-code>superclass_id</inline-code></li>
                 <li><inline-code>class_id</inline-code></li>
                 <li><inline-code>subclass_id</inline-code></li>
-                <li><inline-code>infraclass_id</inline-code></li>
                 <li><inline-code>superorder_id</inline-code></li>
                 <li><inline-code>order_id</inline-code></li>
                 <li><inline-code>suborder_id</inline-code></li>
                 <li><inline-code>infraorder_id</inline-code></li>
-                <li><inline-code>parvorder_id</inline-code></li>
                 <li><inline-code>superfamily_id</inline-code></li>
                 <li><inline-code>family_id</inline-code></li>
                 <li><inline-code>subfamily_id</inline-code></li>
@@ -162,6 +172,7 @@
                 <li><inline-code>species_subgroup_id</inline-code></li>
                 <li><inline-code>species_id</inline-code></li>
                 <li><inline-code>subspecies_id</inline-code></li>
+                <li><inline-code>strain_id</inline-code></li>
                 <li><inline-code>varietas_id</inline-code></li>
                 <li><inline-code>forma_id</inline-code></li>
             </ul>
@@ -180,12 +191,10 @@
                 <li><inline-code>superclass_name</inline-code></li>
                 <li><inline-code>class_name</inline-code></li>
                 <li><inline-code>subclass_name</inline-code></li>
-                <li><inline-code>infraclass_name</inline-code></li>
                 <li><inline-code>superorder_name</inline-code></li>
                 <li><inline-code>order_name</inline-code></li>
                 <li><inline-code>suborder_name</inline-code></li>
                 <li><inline-code>infraorder_name</inline-code></li>
-                <li><inline-code>parvorder_name</inline-code></li>
                 <li><inline-code>superfamily_name</inline-code></li>
                 <li><inline-code>family_name</inline-code></li>
                 <li><inline-code>subfamily_name</inline-code></li>
@@ -197,6 +206,7 @@
                 <li><inline-code>species_subgroup_name</inline-code></li>
                 <li><inline-code>species_name</inline-code></li>
                 <li><inline-code>subspecies_name</inline-code></li>
+                <li><inline-code>strain_name</inline-code></li>
                 <li><inline-code>varietas_name</inline-code></li>
                 <li><inline-code>forma_name</inline-code></li>
             </ul>
@@ -286,6 +296,23 @@
                                 style="font-size: 85%;"
                             >
                                 Value: Must be <inline-code>true</inline-code> or <inline-code>false</inline-code> (default)
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <b>validate_taxa</b>
+                            <br>
+                            <i style="font-size: 85%;">optional</i>
+                        </td>
+                        <td class="py-3">
+                            Ignore invalid and uninformative taxa when calculating the lowest common ancestor.
+                            <br>
+                            <div
+                                class="mt-3"
+                                style="font-size: 85%;"
+                            >
+                                Value: Must be <inline-code>true</inline-code> (default) or <inline-code>false</inline-code>
                             </div>
                         </td>
                     </tr>
@@ -475,7 +502,7 @@ const response4 = ref({});
 const response5 = ref({});
 
 const input = ref("");
-const equate_il = ref(false);
+const equate_il = ref(true);
 const extra = ref(false);
 const names = ref(false);
 

--- a/src/components/pages/documentation/apidocs/APIPept2ProtPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2ProtPage.vue
@@ -63,7 +63,7 @@
                 </h3>
                 <p>
                     <inline-code>equate_il</inline-code> is an optional parameter and can either be <inline-code>true</inline-code> or <inline-code>false</inline-code>.
-                    When not set explicitly, the parameter defaults to <inline-code>false</inline-code>.
+                    When not set explicitly, the parameter defaults to <inline-code>true</inline-code>.
                     When the parameter is set to <inline-code>true</inline-code>, isoleucine (I) and leucine (L) are equated when matching peptides to UniProt entries.
                     This setting is similar to checking the <i>Equate I and L</i> checkbox when performing a search with the <r-link
                         to="/tpa"
@@ -96,15 +96,6 @@
                 </static-alert>
 
                 <h3 class="font-weight-medium">
-                    cutoff
-                </h3>
-                <p>
-                    <inline-code>cutoff</inline-code> is an optional parameter and can only be a <inline-code>natural number (>0)</inline-code>.
-                    When not set explicitly, the parameter defaults to <inline-code>10000</inline-code>. When an input peptide matches more than
-                    <inline-code>cutoff</inline-code> UniProt entries, the response will be truncated.
-                </p>
-
-                <h3 class="font-weight-medium">
                     tryptic
                 </h3>
                 <p>
@@ -133,6 +124,7 @@
                     <li><inline-code>uniprot_id</inline-code>: the UniProt accession number of the matching record</li>
                     <li><inline-code>protein_name</inline-code>: the name of the protein of the matching record</li>
                     <li><inline-code>taxon_id</inline-code>: the NCBI taxon id of the organism associated with the matching record</li>
+                    <li><inline-code>protein</inline-code>: the amino acid sequence of the matching record</li>
                 </ul>
 
                 When the <inline-code>extra</inline-code> parameter is set to <inline-code>true</inline-code>, objects contain the following additional fields extracted from the
@@ -142,6 +134,7 @@
                     <li><inline-code>taxon_name</inline-code>: the name of the organism associated with the matching UniProt entry</li>
                     <li><inline-code>ec_references</inline-code>: a space separated list of associated <initialism>EC</initialism> numbers</li>
                     <li><inline-code>go_references</inline-code>: a space separated list of associated <initialism>GO</initialism> terms</li>
+                    <li><inline-code>interpro_references</inline-code>: a space separated list of associated InterPro entry codes</li>
                 </ul>
             </v-card-text>
         </header-body-card>
@@ -213,23 +206,6 @@
                                 style="font-size: 85%;"
                             >
                                 Value: Must be <inline-code>true</inline-code> or <inline-code>false</inline-code> (default)
-                            </div>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <b>cutoff</b>
-                            <br>
-                            <i style="font-size: 85%;">optional</i>
-                        </td>
-                        <td class="py-3">
-                            Sets a limit on the amount of matched proteins that are used for the response.
-                            <br>
-                            <div
-                                class="mt-3"
-                                style="font-size: 85%;"
-                            >
-                                Value: Must be a <inline-code>natural number (>0)</inline-code>
                             </div>
                         </td>
                     </tr>
@@ -410,7 +386,7 @@ const response3 = ref({});
 const response4 = ref({});
 
 const input = ref("");
-const equate_il = ref(false);
+const equate_il = ref(true);
 const extra = ref(false);
 
 const tryItResponse = ref({});

--- a/src/components/pages/documentation/apidocs/APIPept2TaxaPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPept2TaxaPage.vue
@@ -63,7 +63,7 @@
             </h3>
             <p>
                 <inline-code>equate_il</inline-code> is an optional parameter and can either be <inline-code>true</inline-code> or <inline-code>false</inline-code>. When not set explicitly, the parameter
-                defaults to <inline-code>false</inline-code>. When the parameter is set to <inline-code>true</inline-code>, isoleucine (I) and leucine (L) are equated when matching tryptic
+                defaults to <inline-code>true</inline-code>. When the parameter is set to <inline-code>true</inline-code>, isoleucine (I) and leucine (L) are equated when matching tryptic
                 peptides to UniProt entries. This setting is similar to checking the <i>Equate I and L</i> checkbox when performing a search with the
                 <r-link
                     to="/tpa"
@@ -150,6 +150,11 @@
                 <li><inline-code>taxon_rank</inline-code>: the taxonomic rank of the organism associated with the matching record</li>
             </ul>
 
+            When the <inline-code>compact</inline-code> parameter is set to <inline-code>true</inline-code>, each object instead contains
+            <inline-code>peptide</inline-code>, <inline-code>cutoff_used</inline-code> and a single <inline-code>taxa</inline-code> field holding the list of
+            matched taxon identifiers. One object is returned per peptide rather than one per matched taxon, and the
+            <inline-code>extra</inline-code> and <inline-code>names</inline-code> parameters have no effect.
+
             When the <inline-code>extra</inline-code> parameter is set to <inline-code>true</inline-code>, objects contain additional information about the lineages of the organism extracted from the <initialism>NCBI</initialism> taxonomy.
             The taxon id of each rank in the lineage is specified using the following information fields:
 
@@ -164,12 +169,10 @@
                 <li><inline-code>superclass_id</inline-code></li>
                 <li><inline-code>class_id</inline-code></li>
                 <li><inline-code>subclass_id</inline-code></li>
-                <li><inline-code>infraclass_id</inline-code></li>
                 <li><inline-code>superorder_id</inline-code></li>
                 <li><inline-code>order_id</inline-code></li>
                 <li><inline-code>suborder_id</inline-code></li>
                 <li><inline-code>infraorder_id</inline-code></li>
-                <li><inline-code>parvorder_id</inline-code></li>
                 <li><inline-code>superfamily_id</inline-code></li>
                 <li><inline-code>family_id</inline-code></li>
                 <li><inline-code>subfamily_id</inline-code></li>
@@ -181,6 +184,7 @@
                 <li><inline-code>species_subgroup_id</inline-code></li>
                 <li><inline-code>species_id</inline-code></li>
                 <li><inline-code>subspecies_id</inline-code></li>
+                <li><inline-code>strain_id</inline-code></li>
                 <li><inline-code>varietas_id</inline-code></li>
                 <li><inline-code>forma_id</inline-code></li>
             </ul>
@@ -198,12 +202,10 @@
                 <li><inline-code>superclass_name</inline-code></li>
                 <li><inline-code>class_name</inline-code></li>
                 <li><inline-code>subclass_name</inline-code></li>
-                <li><inline-code>infraclass_name</inline-code></li>
                 <li><inline-code>superorder_name</inline-code></li>
                 <li><inline-code>order_name</inline-code></li>
                 <li><inline-code>suborder_name</inline-code></li>
                 <li><inline-code>infraorder_name</inline-code></li>
-                <li><inline-code>parvorder_name</inline-code></li>
                 <li><inline-code>superfamily_name</inline-code></li>
                 <li><inline-code>family_name</inline-code></li>
                 <li><inline-code>subfamily_name</inline-code></li>
@@ -215,6 +217,7 @@
                 <li><inline-code>species_subgroup_name</inline-code></li>
                 <li><inline-code>species_name</inline-code></li>
                 <li><inline-code>subspecies_name</inline-code></li>
+                <li><inline-code>strain_name</inline-code></li>
                 <li><inline-code>varietas_name</inline-code></li>
                 <li><inline-code>forma_name</inline-code></li>
             </ul>
@@ -527,7 +530,7 @@ const response4 = ref({});
 const response5 = ref({});
 
 const input = ref("");
-const equate_il = ref(false);
+const equate_il = ref(true);
 const extra = ref(false);
 const names = ref(false);
 

--- a/src/components/pages/documentation/apidocs/APIPeptInfoPage.vue
+++ b/src/components/pages/documentation/apidocs/APIPeptInfoPage.vue
@@ -63,7 +63,7 @@
             </h3>
             <p>
                 <inline-code>equate_il</inline-code> is an optional parameter and can either be <inline-code>true</inline-code> or <inline-code>false</inline-code>.
-                When not set explicitly, the parameter defaults to <inline-code>false</inline-code>.
+                When not set explicitly, the parameter defaults to <inline-code>true</inline-code>.
                 When the parameter is set to <inline-code>true</inline-code>, isoleucine (I) and leucine (L) are equated when matching peptides to UniProt entries.
                 This setting is similar to checking the <i>Equate I and L</i> checkbox when performing a search with the <r-link
                     to="/tpa"
@@ -117,6 +117,18 @@
                     Do not use this parameter unless the extra information fields are needed.
                 </p>
             </static-alert>
+
+            <h3 class="font-weight-medium">
+                validate_taxa
+            </h3>
+            <p>
+                <inline-code>validate_taxa</inline-code> is an optional parameter and can either be <inline-code>true</inline-code> or <inline-code>false</inline-code>.
+                When not set explicitly, the parameter defaults to <inline-code>true</inline-code>.
+                When the parameter is set to <inline-code>true</inline-code>, taxa that are no longer valid in the <initialism>NCBI</initialism> taxonomy, as well as
+                taxa that carry no meaningful classification (such as <i>uncultured bacterium</i> or <i>Bacteria incertae sedis</i>), are left out of the
+                calculation. Setting it to <inline-code>false</inline-code> takes all taxa into account, which usually results in a less specific
+                lowest common ancestor.
+            </p>
         </header-body-card>
 
         <!-- Response Card -->
@@ -204,12 +216,10 @@
                 <li><inline-code>superclass_id</inline-code></li>
                 <li><inline-code>class_id</inline-code></li>
                 <li><inline-code>subclass_id</inline-code></li>
-                <li><inline-code>infraclass_id</inline-code></li>
                 <li><inline-code>superorder_id</inline-code></li>
                 <li><inline-code>order_id</inline-code></li>
                 <li><inline-code>suborder_id</inline-code></li>
                 <li><inline-code>infraorder_id</inline-code></li>
-                <li><inline-code>parvorder_id</inline-code></li>
                 <li><inline-code>superfamily_id</inline-code></li>
                 <li><inline-code>family_id</inline-code></li>
                 <li><inline-code>subfamily_id</inline-code></li>
@@ -221,6 +231,7 @@
                 <li><inline-code>species_subgroup_id</inline-code></li>
                 <li><inline-code>species_id</inline-code></li>
                 <li><inline-code>subspecies_id</inline-code></li>
+                <li><inline-code>strain_id</inline-code></li>
                 <li><inline-code>varietas_id</inline-code></li>
                 <li><inline-code>forma_id</inline-code></li>
             </ul>
@@ -246,12 +257,10 @@
                 <li><inline-code>superclass_name</inline-code></li>
                 <li><inline-code>class_name</inline-code></li>
                 <li><inline-code>subclass_name</inline-code></li>
-                <li><inline-code>infraclass_name</inline-code></li>
                 <li><inline-code>superorder_name</inline-code></li>
                 <li><inline-code>order_name</inline-code></li>
                 <li><inline-code>suborder_name</inline-code></li>
                 <li><inline-code>infraorder_name</inline-code></li>
-                <li><inline-code>parvorder_name</inline-code></li>
                 <li><inline-code>superfamily_name</inline-code></li>
                 <li><inline-code>family_name</inline-code></li>
                 <li><inline-code>subfamily_name</inline-code></li>
@@ -263,6 +272,7 @@
                 <li><inline-code>species_subgroup_name</inline-code></li>
                 <li><inline-code>species_name</inline-code></li>
                 <li><inline-code>subspecies_name</inline-code></li>
+                <li><inline-code>strain_name</inline-code></li>
                 <li><inline-code>varietas_name</inline-code></li>
                 <li><inline-code>forma_name</inline-code></li>
             </ul>
@@ -375,6 +385,23 @@
                                 style="font-size: 85%;"
                             >
                                 Value: Must be <inline-code>true</inline-code> or <inline-code>false</inline-code> (default)
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <b>validate_taxa</b>
+                            <br>
+                            <i style="font-size: 85%;">optional</i>
+                        </td>
+                        <td class="py-3">
+                            Ignore invalid and uninformative taxa when calculating the lowest common ancestor.
+                            <br>
+                            <div
+                                class="mt-3"
+                                style="font-size: 85%;"
+                            >
+                                Value: Must be <inline-code>true</inline-code> (default) or <inline-code>false</inline-code>
                             </div>
                         </td>
                     </tr>
@@ -590,7 +617,7 @@ const response5 = ref({});
 const response6 = ref({});
 
 const input = ref("");
-const equate_il = ref(false);
+const equate_il = ref(true);
 const extra = ref(false);
 const domains = ref(false);
 const names = ref(false);

--- a/src/components/pages/documentation/apidocs/APIProtInfoPage.vue
+++ b/src/components/pages/documentation/apidocs/APIProtInfoPage.vue
@@ -167,12 +167,10 @@
                 <li><inline-code>superclass_id</inline-code></li>
                 <li><inline-code>class_id</inline-code></li>
                 <li><inline-code>subclass_id</inline-code></li>
-                <li><inline-code>infraclass_id</inline-code></li>
                 <li><inline-code>superorder_id</inline-code></li>
                 <li><inline-code>order_id</inline-code></li>
                 <li><inline-code>suborder_id</inline-code></li>
                 <li><inline-code>infraorder_id</inline-code></li>
-                <li><inline-code>parvorder_id</inline-code></li>
                 <li><inline-code>superfamily_id</inline-code></li>
                 <li><inline-code>family_id</inline-code></li>
                 <li><inline-code>subfamily_id</inline-code></li>
@@ -184,6 +182,7 @@
                 <li><inline-code>species_subgroup_id</inline-code></li>
                 <li><inline-code>species_id</inline-code></li>
                 <li><inline-code>subspecies_id</inline-code></li>
+                <li><inline-code>strain_id</inline-code></li>
                 <li><inline-code>varietas_id</inline-code></li>
                 <li><inline-code>forma_id</inline-code></li>
             </ul>
@@ -209,12 +208,10 @@
                 <li><inline-code>superclass_name</inline-code></li>
                 <li><inline-code>class_name</inline-code></li>
                 <li><inline-code>subclass_name</inline-code></li>
-                <li><inline-code>infraclass_name</inline-code></li>
                 <li><inline-code>superorder_name</inline-code></li>
                 <li><inline-code>order_name</inline-code></li>
                 <li><inline-code>suborder_name</inline-code></li>
                 <li><inline-code>infraorder_name</inline-code></li>
-                <li><inline-code>parvorder_name</inline-code></li>
                 <li><inline-code>superfamily_name</inline-code></li>
                 <li><inline-code>family_name</inline-code></li>
                 <li><inline-code>subfamily_name</inline-code></li>
@@ -226,6 +223,7 @@
                 <li><inline-code>species_subgroup_name</inline-code></li>
                 <li><inline-code>species_name</inline-code></li>
                 <li><inline-code>subspecies_name</inline-code></li>
+                <li><inline-code>strain_name</inline-code></li>
                 <li><inline-code>varietas_name</inline-code></li>
                 <li><inline-code>forma_name</inline-code></li>
             </ul>
@@ -269,23 +267,6 @@
                                 style="font-size: 85%;"
                             >
                                 Value: string
-                            </div>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <b>equate_il</b>
-                            <br>
-                            <i style="font-size: 85%;">optional</i>
-                        </td>
-                        <td class="py-3">
-                            Equate isoleucine (I) and leucine (L).
-                            <br>
-                            <div
-                                class="mt-3"
-                                style="font-size: 85%;"
-                            >
-                                Value: Must be <inline-code>true</inline-code> (default) or <inline-code>false</inline-code>
                             </div>
                         </td>
                     </tr>
@@ -425,10 +406,10 @@
                 This example retrieves all functional <initialism>EC</initialism>-numbers, <initialism>GO</initialism>-terms, InterPro entries and the lowest common ancestor associated with the protein <i><initialism>A0JP26</initialism></i> including the names of all ranks in the lineage.
             </template>
             <template #post>
-                curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v2/protinfo -d 'input[]=A0JP26' -d 'domains=true' -d 'names=true'
+                curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v2/protinfo -d 'input[]=A0JP26' -d 'extra=true' -d 'names=true'
             </template>
             <template #get>
-                https://api.unipept.ugent.be/api/v2/protinfo.json?input[]=A0JP26&domains=true&names=true
+                https://api.unipept.ugent.be/api/v2/protinfo.json?input[]=A0JP26&extra=true&names=true
             </template>
         </example-card>
 
@@ -521,7 +502,6 @@ const response5 = ref({});
 const response6 = ref({});
 
 const input = ref("");
-const equate_il = ref(false);
 const extra = ref(false);
 const domains = ref(false);
 const names = ref(false);
@@ -529,7 +509,7 @@ const names = ref(false);
 const tryItResponse = ref({});
 
 const doRequest = async () => {
-    tryItResponse.value = await unipeptCommunicator.peptinfo(input.value.split('\n'), equate_il.value, extra.value, domains.value);
+    tryItResponse.value = await unipeptCommunicator.protinfo(input.value.split('\n'), extra.value, domains.value, names.value);
 }
 
 onBeforeMount(async () => {

--- a/src/components/pages/documentation/apidocs/APITaxa2LcaPage.vue
+++ b/src/components/pages/documentation/apidocs/APITaxa2LcaPage.vue
@@ -27,7 +27,7 @@
                 >
                     Parameters
                 </r-link> can be included in the request body (<initialism>POST</initialism>) or in the query string (<initialism>GET</initialism>).
-                The only required parameter is <inline-code>input[]</inline-code>, which takes one or more peptides.
+                The only required parameter is <inline-code>input[]</inline-code>, which takes one or more taxon identifiers.
             </p>
 
             <h3 class="font-weight-medium">
@@ -46,9 +46,9 @@
 
             <static-alert title="Input size">
                 <p>
-                    Unipept puts no restrictions on the number of peptides passed to the <inline-code>input[]</inline-code> parameter.
-                    Keep in mind that searching for lots of peptides at once may cause the request to timeout or, in the case of a <initialism>GET</initialism>-request, exceed the maximum <initialism>URL</initialism> length.
-                    When performing bulk searches, we suggest splitting the input set over requests of 100 peptides each.
+                    Unipept puts no restrictions on the number of taxon identifiers passed to the <inline-code>input[]</inline-code> parameter.
+                    Keep in mind that searching for lots of taxon identifiers at once may cause the request to timeout or, in the case of a <initialism>GET</initialism>-request, exceed the maximum <initialism>URL</initialism> length.
+                    When performing bulk searches, we suggest splitting the input set over requests of 100 taxon identifiers each.
                 </p>
             </static-alert>
 
@@ -89,6 +89,18 @@
                     Do not use this parameter unless the extra information fields are needed.
                 </p>
             </static-alert>
+
+            <h3 class="font-weight-medium">
+                validate_taxa
+            </h3>
+            <p>
+                <inline-code>validate_taxa</inline-code> is an optional parameter and can either be <inline-code>true</inline-code> or <inline-code>false</inline-code>.
+                When not set explicitly, the parameter defaults to <inline-code>true</inline-code>.
+                When the parameter is set to <inline-code>true</inline-code>, taxa that are no longer valid in the <initialism>NCBI</initialism> taxonomy, as well as
+                taxa that carry no meaningful classification (such as <i>uncultured bacterium</i> or <i>Bacteria incertae sedis</i>), are left out of the
+                calculation. Setting it to <inline-code>false</inline-code> takes all taxa into account, which usually results in a less specific
+                lowest common ancestor.
+            </p>
         </header-body-card>
 
         <!-- Response Card -->
@@ -121,12 +133,10 @@
                 <li><inline-code>superclass_id</inline-code></li>
                 <li><inline-code>class_id</inline-code></li>
                 <li><inline-code>subclass_id</inline-code></li>
-                <li><inline-code>infraclass_id</inline-code></li>
                 <li><inline-code>superorder_id</inline-code></li>
                 <li><inline-code>order_id</inline-code></li>
                 <li><inline-code>suborder_id</inline-code></li>
                 <li><inline-code>infraorder_id</inline-code></li>
-                <li><inline-code>parvorder_id</inline-code></li>
                 <li><inline-code>superfamily_id</inline-code></li>
                 <li><inline-code>family_id</inline-code></li>
                 <li><inline-code>subfamily_id</inline-code></li>
@@ -138,6 +148,7 @@
                 <li><inline-code>species_subgroup_id</inline-code></li>
                 <li><inline-code>species_id</inline-code></li>
                 <li><inline-code>subspecies_id</inline-code></li>
+                <li><inline-code>strain_id</inline-code></li>
                 <li><inline-code>varietas_id</inline-code></li>
                 <li><inline-code>forma_id</inline-code></li>
             </ul>
@@ -155,12 +166,10 @@
                 <li><inline-code>superclass_name</inline-code></li>
                 <li><inline-code>class_name</inline-code></li>
                 <li><inline-code>subclass_name</inline-code></li>
-                <li><inline-code>infraclass_name</inline-code></li>
                 <li><inline-code>superorder_name</inline-code></li>
                 <li><inline-code>order_name</inline-code></li>
                 <li><inline-code>suborder_name</inline-code></li>
                 <li><inline-code>infraorder_name</inline-code></li>
-                <li><inline-code>parvorder_name</inline-code></li>
                 <li><inline-code>superfamily_name</inline-code></li>
                 <li><inline-code>family_name</inline-code></li>
                 <li><inline-code>subfamily_name</inline-code></li>
@@ -172,6 +181,7 @@
                 <li><inline-code>species_subgroup_name</inline-code></li>
                 <li><inline-code>species_name</inline-code></li>
                 <li><inline-code>subspecies_name</inline-code></li>
+                <li><inline-code>strain_name</inline-code></li>
                 <li><inline-code>varietas_name</inline-code></li>
                 <li><inline-code>forma_name</inline-code></li>
             </ul>
@@ -247,6 +257,23 @@
                             </div>
                         </td>
                     </tr>
+                    <tr>
+                        <td>
+                            <b>validate_taxa</b>
+                            <br>
+                            <i style="font-size: 85%;">optional</i>
+                        </td>
+                        <td class="py-3">
+                            Ignore invalid and uninformative taxa when calculating the lowest common ancestor.
+                            <br>
+                            <div
+                                class="mt-3"
+                                style="font-size: 85%;"
+                            >
+                                Value: Must be <inline-code>true</inline-code> (default) or <inline-code>false</inline-code>
+                            </div>
+                        </td>
+                    </tr>
                 </tbody>
             </v-table>
         </header-body-card>
@@ -304,7 +331,7 @@
 
         <example-card
             class="mt-5"
-            title="Retrieve all UniProt entries containing a single peptide, while equating I and L"
+            title="Retrieve the taxonomic lowest common ancestor and its lineage names for a given list of taxon identifiers"
             :response="response3"
         >
             <template #description>
@@ -364,7 +391,7 @@
                         v-model="names"
                         color="primary"
                         inset
-                        label="equate_il"
+                        label="names"
                         density="compact"
                         hide-details
                     />

--- a/src/components/pages/documentation/apidocs/APITaxa2TreePage.vue
+++ b/src/components/pages/documentation/apidocs/APITaxa2TreePage.vue
@@ -26,14 +26,23 @@
                 >
                     Parameters
                 </r-link> can be included in the request body (<initialism>POST</initialism>) or in the query string (<initialism>GET</initialism>).
-                The only required parameter is <inline-code>input[]</inline-code>, which takes one or more peptides.
             </p>
+
+            <static-alert title="GET and POST take different parameters">
+                <p>
+                    Unlike the other methods, taxa2tree does not accept the same parameters for both request types.
+                    A <initialism>GET</initialism>-request takes <inline-code>input[]</inline-code>, a plain list of taxon identifiers.
+                    A <initialism>POST</initialism>-request takes <inline-code>counts</inline-code>, an object that maps taxon identifiers onto the number of
+                    times each of them occurs. Sending <inline-code>input[]</inline-code> in a <initialism>POST</initialism>-body is silently ignored and returns
+                    an empty tree.
+                </p>
+            </static-alert>
 
             <h3 class="font-weight-medium">
                 input
             </h3>
             <p>
-                <inline-code>input[]</inline-code> is a required parameter that takes at least one taxon identifier.
+                <inline-code>input[]</inline-code> is the required parameter of a <initialism>GET</initialism>-request and takes at least one taxon identifier.
                 Unipept will compute and return the taxonomic tree for the given taxa.
                 To pass multiple taxon identifiers, simply add multiple <inline-code>input[]</inline-code> parameters (see <r-link
                     to="#example"
@@ -41,13 +50,31 @@
                 >
                     example
                 </r-link>).
+                Each identifier counts once towards the tree; pass <inline-code>counts</inline-code> instead if you need to weigh them.
+            </p>
+
+            <h3 class="font-weight-medium">
+                counts
+            </h3>
+            <p>
+                <inline-code>counts</inline-code> is the required parameter of a <initialism>POST</initialism>-request and takes an object with taxon identifiers
+                as keys and the number of occurrences of each taxon as values. The counts end up in the <inline-code>count</inline-code> and
+                <inline-code>self_count</inline-code> fields of the resulting tree, which lets you build a tree that is weighted by, for example, the number of
+                peptides assigned to each taxon (see <r-link
+                    to="#example2"
+                    router
+                >
+                    example
+                </r-link>).
+                It can be sent either as <initialism>JSON</initialism> (with a <inline-code>Content-Type: application/json</inline-code> header) or as
+                form-encoded <inline-code>counts[<i>taxon_id</i>]</inline-code> parameters.
             </p>
 
             <static-alert title="Input size">
                 <p>
-                    Unipept puts no restrictions on the number of peptides passed to the <inline-code>input[]</inline-code> parameter.
-                    Keep in mind that searching for lots of peptides at once may cause the request to timeout or, in the case of a <initialism>GET</initialism>-request, exceed the maximum <initialism>URL</initialism> length.
-                    When performing bulk searches, we suggest splitting the input set over requests of 100 peptides each.
+                    Unipept puts no restrictions on the number of taxon identifiers passed to the <inline-code>input[]</inline-code> parameter.
+                    Keep in mind that searching for lots of taxon identifiers at once may cause the request to timeout or, in the case of a <initialism>GET</initialism>-request, exceed the maximum <initialism>URL</initialism> length.
+                    When performing bulk searches, we suggest splitting the input set over requests of 100 taxon identifiers each.
                 </p>
             </static-alert>
         </header-body-card>
@@ -142,12 +169,12 @@
                 <tbody>
                     <tr>
                         <td>
-                            <b>Input[]</b>
+                            <b>counts</b>
                             <br>
                             <i style="font-size: 85%;">required</i>
                         </td>
                         <td class="py-3">
-                            List of taxon identifiers and associated counts to calculate the taxonomic tree for. Should be a <initialism>JSON</initialism>-object
+                            Taxon identifiers and associated counts to calculate the taxonomic tree for. Should be a <initialism>JSON</initialism>-object
                             with taxon id's as keys and counts as values.
                             <br>
                             <div
@@ -184,7 +211,7 @@
                 </r-link>).
             </template>
             <template #post>
-                curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v2/taxa2tree -d 'input[]=817' -d 'input[]=329854' -d 'input[]=1099853'
+                curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v2/taxa2tree -d 'counts[817]=1' -d 'counts[329854]=1' -d 'counts[1099853]=1'
             </template>
             <template #get>
                 https://api.unipept.ugent.be/api/v2/taxa2tree.json?input[]=817&input[]=329854&input[]=1099853
@@ -192,9 +219,10 @@
         </example-card>
 
         <example-card
+            id="example2"
             class="mt-5"
-            title="Retrieve the taxonomic tree and its lineage for a given list of taxon identifiers"
-            :response="response1"
+            title="Calculate the taxonomic tree for a given list of taxon identifiers and their counts"
+            :response="response2"
         >
             <template #description>
                 This example calculates and retrieves the taxonomic tree of <i>Bacteroides fragilis</i> (taxon id <r-link to="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=817">
@@ -203,10 +231,10 @@
                     329854
                 </r-link>) and <i>Coprobacter fastidiosus</i> (taxon id <r-link to="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=1099853">
                     1099853
-                </r-link>).
+                </r-link>), weighted by counts of respectively 3, 5 and 7.
             </template>
             <template #post>
-                curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v2/taxa2tree --data '{"counts": {"817": 3, "329854": 5, "1099853": 7}}'
+                curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' api.unipept.ugent.be/api/v2/taxa2tree --data '{"counts": {"817": 3, "329854": 5, "1099853": 7}}'
             </template>
             <template #get>
                 Can only be performed with a POST-request
@@ -277,7 +305,7 @@ const doRequest = async () => {
 
 onBeforeMount(async () => {
     response1.value = await unipeptCommunicator.taxa2tree(["817", "329854", "1099853"]);
-    response2.value = {"gist":"https://gist.github.com/1d3e41bf41c4ca5b97aa802c58484393"}
+    response2.value = await unipeptCommunicator.taxa2treeCounts({ "817": 3, "329854": 5, "1099853": 7 });
 })
 </script>
 

--- a/src/components/pages/documentation/apidocs/APITaxonomyPage.vue
+++ b/src/components/pages/documentation/apidocs/APITaxonomyPage.vue
@@ -27,7 +27,7 @@
                 >
                     Parameters
                 </r-link> can be included in the request body (<initialism>POST</initialism>) or in the query string (<initialism>GET</initialism>).
-                The only required parameter is <inline-code>input[]</inline-code>, which takes one or more peptides.
+                The only required parameter is <inline-code>input[]</inline-code>, which takes one or more taxon identifiers.
             </p>
 
             <h3 class="font-weight-medium">
@@ -45,9 +45,9 @@
 
             <static-alert title="Input size">
                 <p>
-                    Unipept puts no restrictions on the number of peptides passed to the <inline-code>input[]</inline-code> parameter.
-                    Keep in mind that searching for lots of peptides at once may cause the request to timeout or, in the case of a <initialism>GET</initialism>-request, exceed the maximum <initialism>URL</initialism> length.
-                    When performing bulk searches, we suggest splitting the input set over requests of 100 peptides each.
+                    Unipept puts no restrictions on the number of taxon identifiers passed to the <inline-code>input[]</inline-code> parameter.
+                    Keep in mind that searching for lots of taxon identifiers at once may cause the request to timeout or, in the case of a <initialism>GET</initialism>-request, exceed the maximum <initialism>URL</initialism> length.
+                    When performing bulk searches, we suggest splitting the input set over requests of 100 taxon identifiers each.
                 </p>
             </static-alert>
 
@@ -117,12 +117,10 @@
                 <li><inline-code>superclass</inline-code></li>
                 <li><inline-code>class</inline-code></li>
                 <li><inline-code>subclass</inline-code></li>
-                <li><inline-code>infraclass</inline-code></li>
                 <li><inline-code>superorder</inline-code></li>
                 <li><inline-code>order</inline-code></li>
                 <li><inline-code>suborder</inline-code></li>
                 <li><inline-code>infraorder</inline-code></li>
-                <li><inline-code>parvorder</inline-code></li>
                 <li><inline-code>superfamily</inline-code></li>
                 <li><inline-code>family</inline-code></li>
                 <li><inline-code>subfamily</inline-code></li>
@@ -134,6 +132,7 @@
                 <li><inline-code>species_subgroup</inline-code></li>
                 <li><inline-code>species</inline-code></li>
                 <li><inline-code>subspecies</inline-code></li>
+                <li><inline-code>strain</inline-code></li>
                 <li><inline-code>varietas</inline-code></li>
                 <li><inline-code>forma</inline-code></li>
             </ul>
@@ -169,12 +168,10 @@
                 <li><inline-code>superclass_id</inline-code></li>
                 <li><inline-code>class_id</inline-code></li>
                 <li><inline-code>subclass_id</inline-code></li>
-                <li><inline-code>infraclass_id</inline-code></li>
                 <li><inline-code>superorder_id</inline-code></li>
                 <li><inline-code>order_id</inline-code></li>
                 <li><inline-code>suborder_id</inline-code></li>
                 <li><inline-code>infraorder_id</inline-code></li>
-                <li><inline-code>parvorder_id</inline-code></li>
                 <li><inline-code>superfamily_id</inline-code></li>
                 <li><inline-code>family_id</inline-code></li>
                 <li><inline-code>subfamily_id</inline-code></li>
@@ -186,6 +183,7 @@
                 <li><inline-code>species_subgroup_id</inline-code></li>
                 <li><inline-code>species_id</inline-code></li>
                 <li><inline-code>subspecies_id</inline-code></li>
+                <li><inline-code>strain_id</inline-code></li>
                 <li><inline-code>varietas_id</inline-code></li>
                 <li><inline-code>forma_id</inline-code></li>
             </ul>
@@ -204,12 +202,10 @@
                 <li><inline-code>superclass_name</inline-code></li>
                 <li><inline-code>class_name</inline-code></li>
                 <li><inline-code>subclass_name</inline-code></li>
-                <li><inline-code>infraclass_name</inline-code></li>
                 <li><inline-code>superorder_name</inline-code></li>
                 <li><inline-code>order_name</inline-code></li>
                 <li><inline-code>suborder_name</inline-code></li>
                 <li><inline-code>infraorder_name</inline-code></li>
-                <li><inline-code>parvorder_name</inline-code></li>
                 <li><inline-code>superfamily_name</inline-code></li>
                 <li><inline-code>family_name</inline-code></li>
                 <li><inline-code>subfamily_name</inline-code></li>
@@ -221,8 +217,18 @@
                 <li><inline-code>species_subgroup_name</inline-code></li>
                 <li><inline-code>species_name</inline-code></li>
                 <li><inline-code>subspecies_name</inline-code></li>
+                <li><inline-code>strain_name</inline-code></li>
                 <li><inline-code>varietas_name</inline-code></li>
                 <li><inline-code>forma_name</inline-code></li>
+            </ul>
+
+            When the <inline-code>descendants</inline-code> parameter is set to <inline-code>true</inline-code>, objects contain one additional field:
+
+            <ul class="my-3">
+                <li>
+                    <inline-code>descendants</inline-code>: a list of the <initialism>NCBI</initialism> taxon ids of all taxa below the requested taxon that sit
+                    at one of the ranks given by <inline-code>descendants_ranks</inline-code>.
+                </li>
             </ul>
         </header-body-card>
 
@@ -374,10 +380,10 @@
                 </r-link>).
             </template>
             <template #post>
-                curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v2/taxa2lca -d 'input[]=817' -d 'input[]=329854'
+                curl -X POST -H 'Accept: application/json' api.unipept.ugent.be/api/v2/taxonomy -d 'input[]=817' -d 'input[]=329854'
             </template>
             <template #get>
-                https://api.unipept.ugent.be/api/v2/taxa2lca.json?input[]=817&input[]=329854
+                https://api.unipept.ugent.be/api/v2/taxonomy.json?input[]=817&input[]=329854
             </template>
         </example-card>
 

--- a/src/logic/communicators/unipept/UnipeptCommunicator.ts
+++ b/src/logic/communicators/unipept/UnipeptCommunicator.ts
@@ -2,7 +2,7 @@ const base = "https://api.unipept.ugent.be/api/v2/";
 const privateBase = "https://api.unipept.ugent.be/private_api/"
 
 export default class UnipeptCommunicator {
-    public async pept2prot(input: string[], equate_il = false, extra = false): Promise<string[]> {
+    public async pept2prot(input: string[], equate_il = true, extra = false): Promise<string[]> {
         const params = new URLSearchParams({
             equate_il: equate_il.toString(),
             extra: extra.toString()
@@ -15,7 +15,7 @@ export default class UnipeptCommunicator {
         return await fetch(this.prepareURL(base, "pept2prot.json", params)).then(r => r.json());
     }
 
-    public async pept2taxa(input: string[], equate_il = false, extra = false, names = false): Promise<string[]> {
+    public async pept2taxa(input: string[], equate_il = true, extra = false, names = false): Promise<string[]> {
         const params = new URLSearchParams({
             equate_il: equate_il.toString(),
             extra: extra.toString(),
@@ -29,7 +29,7 @@ export default class UnipeptCommunicator {
         return await fetch(this.prepareURL(base, "pept2taxa.json", params)).then(r => r.json());
     }
 
-    public async pept2lca(input: string[], equate_il = false, extra = false, names = false): Promise<string[]> {
+    public async pept2lca(input: string[], equate_il = true, extra = false, names = false): Promise<string[]> {
         const params = new URLSearchParams({
             equate_il: equate_il.toString(),
             extra: extra.toString(),
@@ -43,7 +43,7 @@ export default class UnipeptCommunicator {
         return await fetch(this.prepareURL(base, "pept2lca.json", params)).then(r => r.json());
     }
 
-    public async pept2ec(input: string[], equate_il = false, extra = false): Promise<string[]> {
+    public async pept2ec(input: string[], equate_il = true, extra = false): Promise<string[]> {
         const params = new URLSearchParams({
             equate_il: equate_il.toString(),
             extra: extra.toString()
@@ -56,7 +56,7 @@ export default class UnipeptCommunicator {
         return await fetch(this.prepareURL(base, "pept2ec.json", params)).then(r => r.json());
     }
 
-    public async pept2go(input: string[], equate_il = false, extra = false, domains = false): Promise<string[]> {
+    public async pept2go(input: string[], equate_il = true, extra = false, domains = false): Promise<string[]> {
         const params = new URLSearchParams({
             equate_il: equate_il.toString(),
             extra: extra.toString(),
@@ -70,7 +70,7 @@ export default class UnipeptCommunicator {
         return await fetch(this.prepareURL(base, "pept2go.json", params)).then(r => r.json());
     }
 
-    public async pept2interpro(input: string[], equate_il = false, extra = false, domains = false): Promise<string[]> {
+    public async pept2interpro(input: string[], equate_il = true, extra = false, domains = false): Promise<string[]> {
         const params = new URLSearchParams({
             equate_il: equate_il.toString(),
             extra: extra.toString(),
@@ -84,7 +84,7 @@ export default class UnipeptCommunicator {
         return await fetch(this.prepareURL(base, "pept2interpro.json", params)).then(r => r.json());
     }
 
-    public async pept2funct(input: string[], equate_il = false, extra = false, domains = false): Promise<string[]> {
+    public async pept2funct(input: string[], equate_il = true, extra = false, domains = false): Promise<string[]> {
         const params = new URLSearchParams({
             equate_il: equate_il.toString(),
             extra: extra.toString(),
@@ -98,7 +98,7 @@ export default class UnipeptCommunicator {
         return await fetch(this.prepareURL(base, "pept2funct.json", params)).then(r => r.json());
     }
 
-    public async peptinfo(input: string[], equate_il = false, extra = false, domains = false, names = false): Promise<string[]> {
+    public async peptinfo(input: string[], equate_il = true, extra = false, domains = false, names = false): Promise<string[]> {
         const params = new URLSearchParams({
             equate_il: equate_il.toString(),
             extra: extra.toString(),
@@ -150,6 +150,14 @@ export default class UnipeptCommunicator {
         }
 
         return await fetch(this.prepareURL(base, "taxa2tree.json", params)).then(r => r.json());
+    }
+
+    public async taxa2treeCounts(counts: Record<string, number>, link = false): Promise<string[]> {
+        return await fetch(base + "taxa2tree.json", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ counts, link })
+        }).then(r => r.json());
     }
 
     public async taxonomy(input: string[], extra = false, names = false): Promise<string[]> {


### PR DESCRIPTION
This pull request brings the API documentation in line with what `unipept-api` actually does. It is the API-side counterpart to #1872. Every page was diffed against the controller `Parameters` structs and then checked against the live API.

**`equate_il` was documented backwards on all eight pages that have it.** The prose said it defaults to `false`; the API defaults it to `true`, and the parameter table on the same page already said "true (default)", so each page contradicted itself. `UnipeptCommunicator` also hardcoded `equate_il = false`, which meant the rendered example responses were fetched with a different setting than the curl commands printed beside them. Both now default to `true`, as do the "Try it" switches.

**The lineage rank lists were wrong on all seven pages that carry one**, 13 lists in total. They listed `infraclass` and `parvorder`, which no longer exist in the v2 lineage, and omitted `strain`. All 13 now match the 28 ranks the API returns.

**`validate_taxa` was undocumented** on pept2lca, peptinfo and taxa2lca. It defaults to `true` and it changes results, so it now has a prose section and a table row on each.

**taxa2tree was the worst page.** Its POST-parameters table named the parameter `input[]`, but POST takes `counts`, so both POST examples on the page returned an empty tree when run. The request section now explains that GET takes `input[]` and POST takes `counts`, both examples work, the second one renders a real counts-weighted response instead of reusing the first one's, and its title no longer promises a lineage that taxa2tree does not return.

**`cutoff` stays internal.** It was documented on the pept2prot page only; that section and its table row are removed. Worth noting that this does not stop anyone passing it, so if the goal is to keep people from requesting a cutoff of 100000000, the API needs to clamp it server side.

<details>
<summary>Smaller fixes</summary>

- `total_protein_count` on pept2ec, pept2go, pept2interpro and pept2funct is the number of matched proteins carrying **any** functional annotation. It is neither the matched protein count nor the count for the annotation type that endpoint reports: all four return the same figure for a given peptide, so pept2go counts proteins that have only an EC-number. The pages described it as the matched protein count, which is what peptinfo returns. Each page now states what its own endpoint returns. Whether the API should keep this is unipept/unipept-api#103; the wording here gets simpler if that lands, and is correct as things stand.
- pept2prot response was missing `protein` (returned by default) and `interpro_references` (returned with `extra=true`).
- pept2taxa never documented the `compact` response shape, and taxonomy never documented the `descendants` field.
- The protinfo parameter table listed `equate_il`, which protinfo does not accept, and its "Try it" button called `peptinfo` and ignored its own `names` switch.
- The protinfo `names` example passed `domains=true&names=true`, but `names` only takes effect together with `extra`.
- The taxonomy page's second example pointed at the taxa2lca endpoint.
- taxa2lca's third example carried a title copied from pept2prot, and its `names` switch was labelled `equate_il`.
- taxa2lca, taxa2tree and taxonomy all told you `input[]` takes peptides. They take taxon identifiers.
- The overview said V1 requests are redirected to V2. There is no redirect: V1 is served by the V2 implementation and returns 200 directly.

</details>

**Manual testing instructions**
- Visit `/apidocs/taxa2tree` and run both POST examples. Both should return a populated tree; the second should be weighted by 3, 5 and 7, giving a root count of 15.
- Visit `/apidocs/protinfo`, enter `A0JP26` under "Try it" and toggle `names`. The request should go to protinfo, not peptinfo.
- Check any page with a lineage list (for example `/apidocs/pept2lca`) and confirm `strain` is listed and `infraclass` and `parvorder` are gone.
- Confirm `/apidocs/pept2prot` no longer mentions `cutoff`.

`yarn types:check`, `yarn lint`, `yarn build` and `yarn test` all pass. `yarn lint` reports no warnings on the changed files; the 25 errors it reports repo-wide are pre-existing and come from vendored files.


